### PR TITLE
Date format validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if (result.success === true) {
 Satpam has `create` method to create new validator instance.
 
 - Each instance will have cloned validation rules and messages, so it's safe to add or override validation rule without affecting other validator instances or the global satpam validator.
-- The cloned validation rules and messages will be based on the current state of the global satpam validator. See [Custom Rules](#custom-rules) 
+- The cloned validation rules and messages will be based on the current state of the global satpam validator. See [Custom Rules](#custom-rules)
 
 
 
@@ -60,6 +60,7 @@ var validatorTwo = satpam.create();
 - `alpha`
 - `alphanumeric`
 - `date`
+- `date-format:$1`
 - `url`
 - `string`
 - `nonBlank`
@@ -73,7 +74,7 @@ var validatorTwo = satpam.create();
   [examples](https://github.com/sendyhalim/satpam/blob/master/tests/member-of.spec.js#L10)
 - `beginWith:$1`
 
-  Use object notation for defining this rule 
+  Use object notation for defining this rule
   [examples](https://github.com/sendyhalim/satpam/blob/master/tests/begin-with.spec.js#L10)
 - `regex:$1:$2`
 
@@ -119,7 +120,7 @@ var newValidator = satpam.create();
 - Add more validation rules.
 - Validate file types.
 
-## More examples 
+## More examples
 [Here](https://github.com/sendyhalim/satpam/blob/master/tests)
 
 ![Read the source Luke](http://blog.codinghorror.com/content/images/uploads/2012/04/6a0120a85dcdae970b016765373659970b-800wi.jpg)

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var memberOf = require('./validators/member-of');
 var beginWith = require('./validators/begin-with');
 var regex = require('./validators/regex');
 var notEqual = require('./validators/not-equal');
+var dateFormat = require('./validators/date-format');
 
 /*
  * Rules should have format:
@@ -61,7 +62,8 @@ var validation = {
   'memberOf:$1': memberOf.validator,
   'beginWith:$1': beginWith.validator,
   'regex:$1:$2': regex.validator,
-  'not-equal:$1': notEqual.validator
+  'not-equal:$1': notEqual.validator,
+  'date-format:$1': dateFormat.validator
 };
 
 var validationMessages = {
@@ -82,7 +84,8 @@ var validationMessages = {
   'memberOf:$1': memberOf.message,
   'beginWith:$1': beginWith.message,
   'regex:$1:$2': regex.message,
-  'not-equal:$1': notEqual.message
+  'not-equal:$1': notEqual.message,
+  'date-format:$1': dateFormat.message
 };
 
 var ValidationMessage = function () {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "image-type": "^2.0.2",
     "lodash": "^3.7.0",
+    "moment": "^2.10.6",
     "read-chunk": "^1.0.1",
     "validator": "^3.39.0"
   },

--- a/tests/date-format.spec.js
+++ b/tests/date-format.spec.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var expect = require('chai').expect;
+var validator = require('../');
+
+describe('Date validator', function () {
+  var simpleRules = {
+    birthday: ['date-format:YYYY-MM-DD']
+  };
+
+  var getTestObject = function () {
+    return {
+      birthday: '1993-09-02',
+    };
+  };
+
+  it('should success', function () {
+    var result = validator.validate(simpleRules, getTestObject());
+    var err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('birthday');
+  });
+
+  it('should fail', function () {
+    var testObj = getTestObject();
+    testObj.birthday = '02-09-1993';
+    var result = validator.validate(simpleRules, testObj);
+    var err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('birthday');
+    expect(err.birthday.date).to.equal('Date format must conform YYYY-MM-DD.');
+  });
+});
+

--- a/tests/date-format.spec.js
+++ b/tests/date-format.spec.js
@@ -30,7 +30,7 @@ describe('Date validator', function () {
 
     expect(result.success).to.equal(false);
     expect(err).to.have.property('birthday');
-    expect(err.birthday.date).to.equal('Date format must conform YYYY-MM-DD.');
+    expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format YYYY-MM-DD.');
   });
 });
 

--- a/tests/date-format.spec.js
+++ b/tests/date-format.spec.js
@@ -4,33 +4,110 @@ var expect = require('chai').expect;
 var validator = require('../');
 
 describe('Date validator', function () {
-  var simpleRules = {
-    birthday: ['date-format:YYYY-MM-DD']
-  };
-
-  var getTestObject = function () {
-    return {
-      birthday: '1993-09-02',
+  context('given a date-format rule with format DD-MM-YYYY', function () {
+    var simpleRules = {
+      birthday: ['date-format:DD-MM-YYYY']
     };
-  };
 
-  it('should success', function () {
-    var result = validator.validate(simpleRules, getTestObject());
-    var err = result.messages;
+    var getTestObject = function () {
+      return {
+        birthday: '02-09-1993',
+      };
+    };
 
-    expect(result.success).to.equal(true);
-    expect(err).to.not.have.property('birthday');
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('birthday');
+    });
+
+    it('should fail with format YYYY-MM-DD', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '1993-09-02';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format DD-MM-YYYY.');
+    });
+
+    it('should fail with format YYYY-DD-MM', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '1993-02-09';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format DD-MM-YYYY.');
+    });
+
+    it('should fail with format DD-MM', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '02-09';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format DD-MM-YYYY.');
+    });
   });
 
-  it('should fail', function () {
-    var testObj = getTestObject();
-    testObj.birthday = '02-09-1993';
-    var result = validator.validate(simpleRules, testObj);
-    var err = result.messages;
 
-    expect(result.success).to.equal(false);
-    expect(err).to.have.property('birthday');
-    expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format YYYY-MM-DD.');
+  context('given a date-format rule with format MM/YYYY', function () {
+    var simpleRules = {
+      birthday: ['date-format:MM/YYYY']
+    };
+
+    var getTestObject = function () {
+      return {
+        birthday: '09/1993',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('birthday');
+    });
+
+    it('should fail with format YYYY/MM/DD', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '1993/09/02';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format MM/YYYY.');
+    });
+
+    it('should fail with format YYYY/MM', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '2022/12';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format MM/YYYY.');
+    });
+
+    it('should fail with invalid date', function () {
+      var testObj = getTestObject();
+      testObj.birthday = '13/2012';
+      var result = validator.validate(simpleRules, testObj);
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('birthday');
+      expect(err.birthday['date-format:$1']).to.equal('Birthday must be in format MM/YYYY.');
+    });
   });
 });
-

--- a/validators/date-format.js
+++ b/validators/date-format.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var moment = require('moment');
+
+exports = module.exports = {
+  validator: function (val, ruleObj) {
+    if (!val) {
+      return true;
+    }
+
+    return moment(val, ruleObj.params[0], true).isValid();
+  },
+  message: '<%= propertyName %> must be in format <%= ruleParams[0] %>.'
+};
+


### PR DESCRIPTION
Add date format validation

```
var rules = {
  birthday: ['date-format:YYYY-MM-DD']
};

var input = {
  birthday: '27-12-2015'
};

satpam.create().validate(rules, input); // Invalid birthday
```
