### PR TITLE
Add `date-before` and `date-after` validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ var validatorTwo = satpam.create();
 - `alphanumeric`
 - `date`
 - `date-format:<format, e.g. DD-MM-YYYY>`
+- `date-after:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015`
+- `date-before:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015`
 - `url`
 - `string`
 - `nonBlank`

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var beginWith = require('./validators/begin-with');
 var regex = require('./validators/regex');
 var notEqual = require('./validators/not-equal');
 var dateFormat = require('./validators/date-format');
+var dateAfter = require('./validators/date-after');
 
 /*
  * Rules should have format:
@@ -63,7 +64,8 @@ var validation = {
   'beginWith:$1': beginWith.validator,
   'regex:$1:$2': regex.validator,
   'not-equal:$1': notEqual.validator,
-  'date-format:$1': dateFormat.validator
+  'date-format:$1': dateFormat.validator,
+  'date-after:$1:$2': dateAfter.validator
 };
 
 var validationMessages = {
@@ -85,7 +87,8 @@ var validationMessages = {
   'beginWith:$1': beginWith.message,
   'regex:$1:$2': regex.message,
   'not-equal:$1': notEqual.message,
-  'date-format:$1': dateFormat.message
+  'date-format:$1': dateFormat.message,
+  'date-after:$1:$2': dateAfter.message
 };
 
 var ValidationMessage = function () {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ var regex = require('./validators/regex');
 var notEqual = require('./validators/not-equal');
 var dateFormat = require('./validators/date-format');
 var dateAfter = require('./validators/date-after');
+var dateBefore = require('./validators/date-before');
 
 /*
  * Rules should have format:
@@ -65,7 +66,8 @@ var validation = {
   'regex:$1:$2': regex.validator,
   'not-equal:$1': notEqual.validator,
   'date-format:$1': dateFormat.validator,
-  'date-after:$1:$2': dateAfter.validator
+  'date-after:$1:$2': dateAfter.validator,
+  'date-before:$1:$2': dateBefore.validator
 };
 
 var validationMessages = {
@@ -88,7 +90,8 @@ var validationMessages = {
   'regex:$1:$2': regex.message,
   'not-equal:$1': notEqual.message,
   'date-format:$1': dateFormat.message,
-  'date-after:$1:$2': dateAfter.message
+  'date-after:$1:$2': dateAfter.message,
+  'date-before:$1:$2': dateBefore.message
 };
 
 var ValidationMessage = function () {

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -7,11 +7,11 @@ var validator = require('../');
 describe('Date validator', function () {
   context('given a date-after rule with parameter `now`', function () {
     var simpleRules = {
-      vacationDate: ['date-after:now']
+      vacationDate: ['date-after:DD/MM/YYYY:now']
     };
 
     var getTestObject = function () {
-      var tomorrowDate = moment().add(1, 'day').format('DD-MM-YYYY');
+      var tomorrowDate = moment().add(1, 'day').format('DD/MM/YYYY');
 
       return {
         vacationDate: tomorrowDate,

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -25,5 +25,49 @@ describe('Date validator', function () {
       expect(result.success).to.equal(true);
       expect(err).to.not.have.property('vacationDate');
     });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: moment().format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate['date-after:$1:$2']).to.equal('Vacation Date must greater than now.');
+    });
+  });
+
+  context('given a date-after rule with parameter 01-2014', function () {
+    var simpleRules = {
+      vacationDate: ['date-after:MM-YYYY:01-2014']
+    };
+
+    var getTestObject = function () {
+      var tomorrowDate = moment('02-2014', 'MM-YYYY');
+
+      return {
+        vacationDate: tomorrowDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+
+    it('should fail when input has the same month', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: moment('01-2014', 'MM-YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate['date-after:$1:$2']).to.equal('Vacation Date must greater than 01-2014.');
+    });
   });
 });

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -11,10 +11,10 @@ describe('Date validator', function () {
     };
 
     var getTestObject = function () {
-      var tomorrowDate = moment().add(1, 'day').format('DD/MM/YYYY');
+      var futureDate = moment().add(1, 'day').format('DD/MM/YYYY');
 
       return {
-        vacationDate: tomorrowDate,
+        vacationDate: futureDate,
       };
     };
 
@@ -44,10 +44,10 @@ describe('Date validator', function () {
     };
 
     var getTestObject = function () {
-      var tomorrowDate = moment('02-2014', 'MM-YYYY');
+      var futureDate = moment('02-2014', 'MM-YYYY');
 
       return {
-        vacationDate: tomorrowDate,
+        vacationDate: futureDate,
       };
     };
 

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var expect = require('chai').expect;
+var moment = require('moment');
+var validator = require('../');
+
+describe('Date validator', function () {
+  context('given a date-after rule with parameter `now`', function () {
+    var simpleRules = {
+      vacationDate: ['date-after:now']
+    };
+
+    var getTestObject = function () {
+      var tomorrowDate = moment().add(1, 'day').format('DD-MM-YYYY');
+
+      return {
+        vacationDate: tomorrowDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+  });
+});

--- a/tests/date-before.spec.js
+++ b/tests/date-before.spec.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var expect = require('chai').expect;
+var moment = require('moment');
+var validator = require('../');
+
+describe('Date validator', function () {
+  context('given a date-before rule with parameter `now`', function () {
+    var simpleRules = {
+      pastVacationDate: ['date-before:DD/MM/YYYY:now']
+    };
+
+    var getTestObject = function () {
+      var pastDate = moment().subtract(1, 'day').format('DD/MM/YYYY');
+
+      return {
+        pastVacationDate: pastDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: moment().format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('date-before:$1:$2')
+        .that.equals('Past Vacation Date must less than now.');
+    });
+  });
+
+  context('given a date-before rule with parameter 01-2014', function () {
+    var simpleRules = {
+      pastVacationDate: ['date-before:MM-YYYY:01-2014']
+    };
+
+    var getTestObject = function () {
+      var pastDate = moment('12-2013', 'MM-YYYY');
+
+      return {
+        pastVacationDate: pastDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same month', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: moment('01-2014', 'MM-YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('date-before:$1:$2')
+        .that.equals('Past Vacation Date must less than 01-2014.');
+    });
+  });
+});
+

--- a/validators/date-after.js
+++ b/validators/date-after.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var moment = require('moment');
+var NOW = 'now';
+
+exports = module.exports = {
+  validator: function (val, ruleObj) {
+    if (!val) {
+      return true;
+    }
+
+    var date;
+    var dateInputFormat = ruleObj.params[0];
+    var dateInput = moment(val, dateInputFormat);
+
+    if (ruleObj.params[1].toLowerCase() === NOW) {
+      date = moment();
+    } else {
+      date = moment(ruleObj.params[1], dateInputFormat);
+    }
+
+    return dateInput.unix() > date.unix();
+  },
+  message: '<%= propertyName %> must greater than <%= ruleParams[1] %>.'
+};
+

--- a/validators/date-after.js
+++ b/validators/date-after.js
@@ -19,7 +19,7 @@ exports = module.exports = {
       date = moment(ruleObj.params[1], dateInputFormat);
     }
 
-    return dateInput.unix() > date.unix();
+    return dateInput.isAfter(date, 'day');
   },
   message: '<%= propertyName %> must greater than <%= ruleParams[1] %>.'
 };

--- a/validators/date-before.js
+++ b/validators/date-before.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var moment = require('moment');
+var NOW = 'now';
+
+exports = module.exports = {
+  validator: function (val, ruleObj) {
+    if (!val) {
+      return true;
+    }
+
+    var date;
+    var dateInputFormat = ruleObj.params[0];
+    var dateInput = moment(val, dateInputFormat);
+
+    if (ruleObj.params[1].toLowerCase() === NOW) {
+      date = moment();
+    } else {
+      date = moment(ruleObj.params[1], dateInputFormat);
+    }
+
+    return dateInput.isBefore(date, 'day');
+  },
+  message: '<%= propertyName %> must less than <%= ruleParams[1] %>.'
+};
+


### PR DESCRIPTION
```
var rules = {
  vacationDate: 'date-after:DD/MM/YYYY:now',
  pastVacationDate: 'date-before:MM-YYYY:01-2015'
};
```
