### PR TITLE
Add ability to set relative number of `now` parameter on `dateBefore` and `dateAfter` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ var validatorTwo = satpam.create();
 - `alphanumeric`
 - `date`
 - `dateFormat:<format, e.g. DD-MM-YYYY>`
-- `dateAfter:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>`
-- `dateBefore:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>`
+- `dateAfter:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>`
+- `dateBefore:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>`
 - `url`
 - `string`
 - `nonBlank`

--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ var validation = {
   'regex:$1:$2': regex.validator,
   'not-equal:$1': notEqual.validator,
   'dateFormat:$1': dateFormat.validator,
-  'dateAfter:$1:$2': dateAfter.validator,
-  'dateBefore:$1:$2': dateBefore.validator
+  'dateAfter:$1:$2:$3': dateAfter.validator,
+  'dateBefore:$1:$2:$3': dateBefore.validator
 };
 
 var validationMessages = {
@@ -90,8 +90,8 @@ var validationMessages = {
   'regex:$1:$2': regex.message,
   'not-equal:$1': notEqual.message,
   'dateFormat:$1': dateFormat.message,
-  'dateAfter:$1:$2': dateAfter.message,
-  'dateBefore:$1:$2': dateBefore.message
+  'dateAfter:$1:$2:$3': dateAfter.message,
+  'dateBefore:$1:$2:$3': dateBefore.message
 };
 
 var ValidationMessage = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Simple and Effective Object Validator",
   "main": "index.js",
   "scripts": {

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -7,7 +7,7 @@ var validator = require('../');
 describe('Date validator', function () {
   context('given a dateAfter rule with parameter `now`', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD/MM/YYYY:now']
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:0']
     };
 
     var getTestObject = function () {
@@ -34,13 +34,14 @@ describe('Date validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate['dateAfter:$1:$2']).to.equal('Vacation Date must greater than now.');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than now.');
     });
   });
 
   context('given a dateAfter rule with parameter 01-2014', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:MM-YYYY:01-2014']
+      vacationDate: ['dateAfter:MM-YYYY:01-2014:0']
     };
 
     var getTestObject = function () {
@@ -67,7 +68,140 @@ describe('Date validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate['dateAfter:$1:$2']).to.equal('Vacation Date must greater than 01-2014.');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than 01-2014.');
+    });
+  });
+
+  context('given a dateAfter rule with parameter `now` and -365 days', function () {
+    var simpleRules = {
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:-365']
+    };
+
+    var getTestObject = function () {
+      var date = moment().subtract(364, 'days').format('DD/MM/YYYY');
+
+      return {
+        vacationDate: date,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than now minus 365 days.');
+    });
+  });
+
+  context('given a dateAfter rule with parameter `now` and 40 days', function () {
+    var simpleRules = {
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:40']
+    };
+
+    var getTestObject = function () {
+      var date = moment().add(41, 'days').format('DD/MM/YYYY');
+
+      return {
+        vacationDate: date,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than now plus 40 days.');
+    });
+  });
+
+  context('given a dateAfter rule with parameter `02-09` and -10 days', function () {
+    var simpleRules = {
+      vacationDate: ['dateAfter:DD-MM:02-09:-10']
+    };
+
+    var getTestObject = function () {
+      return {
+        vacationDate: '24-08',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: '23-08'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than 02-09 minus 10 days.');
+    });
+  });
+
+  context('given a dateAfter rule with parameter `12-09` and 10 days', function () {
+    var simpleRules = {
+      vacationDate: ['dateAfter:DD-MM:12-09:10']
+    };
+
+    var getTestObject = function () {
+      return {
+        vacationDate: '23-09',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('vacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        vacationDate: '22-09'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('vacationDate');
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+        .that.equals('Vacation Date must greater than 12-09 plus 10 days.');
     });
   });
 });

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var moment = require('moment');
 var validator = require('../');
 
-describe('Date validator', function () {
+describe('Date After validator', function () {
   context('given a dateAfter rule with parameter `now`', function () {
     var simpleRules = {
       vacationDate: ['dateAfter:DD/MM/YYYY:now:0']

--- a/tests/date-before.spec.js
+++ b/tests/date-before.spec.js
@@ -7,7 +7,7 @@ var validator = require('../');
 describe('Date validator', function () {
   context('given a dateBefore rule with parameter `now`', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD/MM/YYYY:now']
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:0']
     };
 
     var getTestObject = function () {
@@ -34,14 +34,14 @@ describe('Date validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
         .that.equals('Past Vacation Date must less than now.');
     });
   });
 
   context('given a dateBefore rule with parameter 01-2014', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:MM-YYYY:01-2014']
+      pastVacationDate: ['dateBefore:MM-YYYY:01-2014:0']
     };
 
     var getTestObject = function () {
@@ -68,8 +68,140 @@ describe('Date validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
         .that.equals('Past Vacation Date must less than 01-2014.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `now` and -365 days', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:-365']
+    };
+
+    var getTestObject = function () {
+      var pastDate = moment().subtract(366, 'days').format('DD/MM/YYYY');
+
+      return {
+        pastVacationDate: pastDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+        .that.equals('Past Vacation Date must less than now minus 365 days.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `now` and 40 days', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:40']
+    };
+
+    var getTestObject = function () {
+      var pastDate = moment().add(39, 'days').format('DD/MM/YYYY');
+
+      return {
+        pastVacationDate: pastDate,
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+        .that.equals('Past Vacation Date must less than now plus 40 days.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `02-09` and -10 days', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD-MM:02-09:-10']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '22-08',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '23-08'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+        .that.equals('Past Vacation Date must less than 02-09 minus 10 days.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `12-09` and 10 days', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD-MM:12-09:10']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '21-09',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '22-09'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+        .that.equals('Past Vacation Date must less than 12-09 plus 10 days.');
     });
   });
 });

--- a/tests/date-before.spec.js
+++ b/tests/date-before.spec.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var moment = require('moment');
 var validator = require('../');
 
-describe('Date validator', function () {
+describe('Date Before validator', function () {
   context('given a dateBefore rule with parameter `now`', function () {
     var simpleRules = {
       pastVacationDate: ['dateBefore:DD/MM/YYYY:now:0']

--- a/tests/date-format.spec.js
+++ b/tests/date-format.spec.js
@@ -3,7 +3,7 @@
 var expect = require('chai').expect;
 var validator = require('../');
 
-describe('Date validator', function () {
+describe('Date Format validator', function () {
   context('given a dateFormat rule with format DD-MM-YYYY', function () {
     var simpleRules = {
       birthday: ['dateFormat:DD-MM-YYYY']

--- a/validators/date-after.js
+++ b/validators/date-after.js
@@ -1,7 +1,17 @@
 'use strict';
 
+var _ = require('lodash');
 var moment = require('moment');
 var NOW = 'now';
+var message = '<%= propertyName %> must greater than <%= ruleParams[1] %>.';
+var self = exports;
+
+// Use object (it will be passed as reference at index.js) to represent the message,
+// because we want to change it dynamically based on the offset parameter
+// based on the offset parameters.
+var messageObj = {
+  toString: _.constant(message)
+};
 
 exports = module.exports = {
   validator: function (val, ruleObj) {
@@ -12,6 +22,7 @@ exports = module.exports = {
     var date;
     var dateInputFormat = ruleObj.params[0];
     var dateInput = moment(val, dateInputFormat);
+    var offset = Number(ruleObj.params[2]);
 
     if (ruleObj.params[1].toLowerCase() === NOW) {
       date = moment();
@@ -19,8 +30,23 @@ exports = module.exports = {
       date = moment(ruleObj.params[1], dateInputFormat);
     }
 
+    messageObj.toString = _.constant(message);
+
+    if (offset) {
+      if (offset < 0) {
+        offset = Math.abs(offset);
+        messageObj.toString = _.constant(
+          '<%= propertyName %> must greater than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> days.'
+        );
+        date = date.subtract(offset, 'days');
+      } else {
+        messageObj.toString = _.constant('<%= propertyName %> must greater than <%= ruleParams[1] %> plus <%= ruleParams[2] %> days.');
+        date = date.add(offset, 'days');
+      }
+    }
+
     return dateInput.isAfter(date, 'day');
   },
-  message: '<%= propertyName %> must greater than <%= ruleParams[1] %>.'
+  message: messageObj
 };
 

--- a/validators/date-before.js
+++ b/validators/date-before.js
@@ -1,7 +1,17 @@
 'use strict';
 
+var _ = require('lodash');
 var moment = require('moment');
 var NOW = 'now';
+var message = '<%= propertyName %> must less than <%= ruleParams[1] %>.';
+var self = exports;
+
+// Use object (it will be passed as reference at index.js) to represent the message,
+// because we want to change it dynamically based on the offset parameter
+// based on the offset parameters.
+var messageObj = {
+  toString: _.constant(message)
+};
 
 exports = module.exports = {
   validator: function (val, ruleObj) {
@@ -12,6 +22,7 @@ exports = module.exports = {
     var date;
     var dateInputFormat = ruleObj.params[0];
     var dateInput = moment(val, dateInputFormat);
+    var offset = Number(ruleObj.params[2]);
 
     if (ruleObj.params[1].toLowerCase() === NOW) {
       date = moment();
@@ -19,8 +30,23 @@ exports = module.exports = {
       date = moment(ruleObj.params[1], dateInputFormat);
     }
 
+    messageObj.toString = _.constant(message);
+
+    if (offset) {
+      if (offset < 0) {
+        offset = Math.abs(offset);
+        messageObj.toString = _.constant(
+          '<%= propertyName %> must less than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> days.'
+        );
+        date = date.subtract(offset, 'days');
+      } else {
+        messageObj.toString = _.constant('<%= propertyName %> must less than <%= ruleParams[1] %> plus <%= ruleParams[2] %> days.');
+        date = date.add(offset, 'days');
+      }
+    }
+
     return dateInput.isBefore(date, 'day');
   },
-  message: '<%= propertyName %> must less than <%= ruleParams[1] %>.'
+  message: messageObj
 };
 


### PR DESCRIPTION
```
var rules = {
  someDate: ['dateAfter:DD/MM/YYYY:now:10'], // Must be after today's date plus 10 days
  anotherDate: ['dateBefore:DD/MM/YYYY:now:10'] // Must be before today's date plus 10 days 
  yowDate: ['dateAfter:DD/MM/YYYY:now:-12'], // Must be after today's date minus 12 days 
  lolDate: ['dateBefore:DD/MM/YYYY:now:-12'] // Must be before today's date minus 12 days  
};
```
