### PR TITLE
Add unit of time parameter to `dateBefore` and `dateAfter` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ var validatorTwo = satpam.create();
 - `alphanumeric`
 - `date`
 - `dateFormat:<format, e.g. DD-MM-YYYY>`
-- `dateAfter:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>`
-- `dateBefore:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>`
+- `dateAfter:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>:<unit of time e.g. 'days'>`
+- `dateBefore:<the date input format, e.g. DD-MM-YYYY>:<date after e.g. 'now' or 20-1-2015>:<offset>:<unit of time e.g. 'days'>`
 - `url`
 - `string`
 - `nonBlank`

--- a/index.js
+++ b/index.js
@@ -66,8 +66,8 @@ var validation = {
   'regex:$1:$2': regex.validator,
   'not-equal:$1': notEqual.validator,
   'dateFormat:$1': dateFormat.validator,
-  'dateAfter:$1:$2:$3': dateAfter.validator,
-  'dateBefore:$1:$2:$3': dateBefore.validator
+  'dateAfter:$1:$2:$3:$4': dateAfter.validator,
+  'dateBefore:$1:$2:$3:$4': dateBefore.validator
 };
 
 var validationMessages = {
@@ -90,8 +90,8 @@ var validationMessages = {
   'regex:$1:$2': regex.message,
   'not-equal:$1': notEqual.message,
   'dateFormat:$1': dateFormat.message,
-  'dateAfter:$1:$2:$3': dateAfter.message,
-  'dateBefore:$1:$2:$3': dateBefore.message
+  'dateAfter:$1:$2:$3:$4': dateAfter.message,
+  'dateBefore:$1:$2:$3:$4': dateBefore.message
 };
 
 var ValidationMessage = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Simple and Effective Object Validator",
   "main": "index.js",
   "scripts": {

--- a/tests/date-after.spec.js
+++ b/tests/date-after.spec.js
@@ -7,7 +7,7 @@ var validator = require('../');
 describe('Date After validator', function () {
   context('given a dateAfter rule with parameter `now`', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD/MM/YYYY:now:0']
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:0:days']
     };
 
     var getTestObject = function () {
@@ -34,14 +34,14 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than now.');
     });
   });
 
   context('given a dateAfter rule with parameter 01-2014', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:MM-YYYY:01-2014:0']
+      vacationDate: ['dateAfter:MM-YYYY:01-2014:0:days']
     };
 
     var getTestObject = function () {
@@ -68,14 +68,14 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than 01-2014.');
     });
   });
 
   context('given a dateAfter rule with parameter `now` and -365 days', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD/MM/YYYY:now:-365']
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:-365:days']
     };
 
     var getTestObject = function () {
@@ -102,14 +102,14 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than now minus 365 days.');
     });
   });
 
   context('given a dateAfter rule with parameter `now` and 40 days', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD/MM/YYYY:now:40']
+      vacationDate: ['dateAfter:DD/MM/YYYY:now:40:days']
     };
 
     var getTestObject = function () {
@@ -136,14 +136,14 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than now plus 40 days.');
     });
   });
 
   context('given a dateAfter rule with parameter `02-09` and -10 days', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD-MM:02-09:-10']
+      vacationDate: ['dateAfter:DD-MM:02-09:-10:days']
     };
 
     var getTestObject = function () {
@@ -168,14 +168,14 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than 02-09 minus 10 days.');
     });
   });
 
   context('given a dateAfter rule with parameter `12-09` and 10 days', function () {
     var simpleRules = {
-      vacationDate: ['dateAfter:DD-MM:12-09:10']
+      vacationDate: ['dateAfter:DD-MM:12-09:10:days']
     };
 
     var getTestObject = function () {
@@ -200,8 +200,73 @@ describe('Date After validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('vacationDate');
-      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3')
+      expect(err.vacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
         .that.equals('Vacation Date must greater than 12-09 plus 10 days.');
     });
   });
+
+  context('given a dateAfter rule with parameter `12-09` and 3 months', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateAfter:DD-MM:12-09:3:months']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '13-12',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '12-12'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
+        .that.equals('Past Vacation Date must greater than 12-09 plus 3 months.');
+    });
+  });
+
+  context('given a dateAfter rule with parameter `04-06-2015` and -4 years', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateAfter:DD-MM-YYYY:04-06-2015:-4:years']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '05-06-2011',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '04-06-2011'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateAfter:$1:$2:$3:$4')
+        .that.equals('Past Vacation Date must greater than 04-06-2015 minus 4 years.');
+    });
+  });
 });
+

--- a/tests/date-before.spec.js
+++ b/tests/date-before.spec.js
@@ -7,7 +7,7 @@ var validator = require('../');
 describe('Date Before validator', function () {
   context('given a dateBefore rule with parameter `now`', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:0']
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:0:days']
     };
 
     var getTestObject = function () {
@@ -34,14 +34,14 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than now.');
     });
   });
 
   context('given a dateBefore rule with parameter 01-2014', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:MM-YYYY:01-2014:0']
+      pastVacationDate: ['dateBefore:MM-YYYY:01-2014:0:days']
     };
 
     var getTestObject = function () {
@@ -68,14 +68,14 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than 01-2014.');
     });
   });
 
   context('given a dateBefore rule with parameter `now` and -365 days', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:-365']
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:-365:days']
     };
 
     var getTestObject = function () {
@@ -102,14 +102,14 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than now minus 365 days.');
     });
   });
 
   context('given a dateBefore rule with parameter `now` and 40 days', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:40']
+      pastVacationDate: ['dateBefore:DD/MM/YYYY:now:40:days']
     };
 
     var getTestObject = function () {
@@ -136,14 +136,14 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than now plus 40 days.');
     });
   });
 
   context('given a dateBefore rule with parameter `02-09` and -10 days', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD-MM:02-09:-10']
+      pastVacationDate: ['dateBefore:DD-MM:02-09:-10:days']
     };
 
     var getTestObject = function () {
@@ -168,14 +168,14 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than 02-09 minus 10 days.');
     });
   });
 
   context('given a dateBefore rule with parameter `12-09` and 10 days', function () {
     var simpleRules = {
-      pastVacationDate: ['dateBefore:DD-MM:12-09:10']
+      pastVacationDate: ['dateBefore:DD-MM:12-09:10:days']
     };
 
     var getTestObject = function () {
@@ -200,8 +200,72 @@ describe('Date Before validator', function () {
 
       expect(result.success).to.equal(false);
       expect(err).to.have.property('pastVacationDate');
-      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3')
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
         .that.equals('Past Vacation Date must less than 12-09 plus 10 days.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `12-09` and 3 months', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD-MM:12-09:3:months']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '11-12',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '12-12'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
+        .that.equals('Past Vacation Date must less than 12-09 plus 3 months.');
+    });
+  });
+
+  context('given a dateBefore rule with parameter `04-06-2015` and -4 years', function () {
+    var simpleRules = {
+      pastVacationDate: ['dateBefore:DD-MM-YYYY:04-06-2015:-4:years']
+    };
+
+    var getTestObject = function () {
+      return {
+        pastVacationDate: '03-06-2011',
+      };
+    };
+
+    it('should success', function () {
+      var result = validator.validate(simpleRules, getTestObject());
+      var err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('pastVacationDate');
+    });
+
+    it('should fail when input has the same date', function () {
+      var result = validator.validate(simpleRules, {
+        pastVacationDate: '04-06-2011'
+      });
+      var err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('pastVacationDate');
+      expect(err.pastVacationDate).to.have.property('dateBefore:$1:$2:$3:$4')
+        .that.equals('Past Vacation Date must less than 04-06-2015 minus 4 years.');
     });
   });
 });

--- a/validators/date-after.js
+++ b/validators/date-after.js
@@ -23,6 +23,7 @@ exports = module.exports = {
     var dateInputFormat = ruleObj.params[0];
     var dateInput = moment(val, dateInputFormat);
     var offset = Number(ruleObj.params[2]);
+    var unit = ruleObj.params[3] || 'days';
 
     if (ruleObj.params[1].toLowerCase() === NOW) {
       date = moment();
@@ -36,12 +37,12 @@ exports = module.exports = {
       if (offset < 0) {
         offset = Math.abs(offset);
         messageObj.toString = _.constant(
-          '<%= propertyName %> must greater than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> days.'
+          '<%= propertyName %> must greater than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> <%= ruleParams[3] %>.'
         );
-        date = date.subtract(offset, 'days');
+        date = date.subtract(offset, unit);
       } else {
-        messageObj.toString = _.constant('<%= propertyName %> must greater than <%= ruleParams[1] %> plus <%= ruleParams[2] %> days.');
-        date = date.add(offset, 'days');
+        messageObj.toString = _.constant('<%= propertyName %> must greater than <%= ruleParams[1] %> plus <%= ruleParams[2] %> <%= ruleParams[3] %>.');
+        date = date.add(offset, unit);
       }
     }
 

--- a/validators/date-before.js
+++ b/validators/date-before.js
@@ -23,6 +23,7 @@ exports = module.exports = {
     var dateInputFormat = ruleObj.params[0];
     var dateInput = moment(val, dateInputFormat);
     var offset = Number(ruleObj.params[2]);
+    var unit = ruleObj.params[3] || 'days';
 
     if (ruleObj.params[1].toLowerCase() === NOW) {
       date = moment();
@@ -36,12 +37,12 @@ exports = module.exports = {
       if (offset < 0) {
         offset = Math.abs(offset);
         messageObj.toString = _.constant(
-          '<%= propertyName %> must less than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> days.'
+          '<%= propertyName %> must less than <%= ruleParams[1] %> minus <%= Math.abs(ruleParams[2]) %> <%= ruleParams[3] %>.'
         );
-        date = date.subtract(offset, 'days');
+        date = date.subtract(offset, unit);
       } else {
-        messageObj.toString = _.constant('<%= propertyName %> must less than <%= ruleParams[1] %> plus <%= ruleParams[2] %> days.');
-        date = date.add(offset, 'days');
+        messageObj.toString = _.constant('<%= propertyName %> must less than <%= ruleParams[1] %> plus <%= ruleParams[2] %> <%= ruleParams[3] %>.');
+        date = date.add(offset, unit);
       }
     }
 


### PR DESCRIPTION
For example:

```
var simpleRules = {
  vacationDate: ['dateAfter:DD/MM/YYYY:now:10:days']
};
```
