### PR TITLE
Fix regex validation when validating null or undefined value

### DIFF
--- a/src/validators/regex.js
+++ b/src/validators/regex.js
@@ -1,6 +1,10 @@
 import R from 'ramda';
 
 const validate = (val, ruleObj) => {
+  if (R.isNil(val)) {
+    return true;
+  }
+
   if (!R.is(String, val)) {
     return false;
   }

--- a/test/validators/regex.spec.js
+++ b/test/validators/regex.spec.js
@@ -19,7 +19,7 @@ describe('regexp validator', () => {
     const rules = {
       name: ['regex:42:g']
     };
-    const result = validator.validate(rules, {name: undefined});
+    const result = validator.validate(rules, {});
     const err = result.messages;
 
     it('should success', () => {

--- a/test/validators/regex.spec.js
+++ b/test/validators/regex.spec.js
@@ -2,6 +2,32 @@ import { expect } from 'chai';
 import validator from '../../lib';
 
 describe('regexp validator', () => {
+  context('given null value', () => {
+    const rules = {
+      name: ['regex:42:g']
+    };
+    const result = validator.validate(rules, {name: null});
+    const err = result.messages;
+
+    it('should success', () => {
+      expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('name');
+    });
+  });
+
+  context('given undefined value', () => {
+    const rules = {
+      name: ['regex:42:g']
+    };
+    const result = validator.validate(rules, {name: undefined});
+    const err = result.messages;
+
+    it('should success', () => {
+      expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('name');
+    });
+  });
+
   context('given value that matches the pattern non digit', () => {
     const rules = {
       name: ['regex:\\D:g']


### PR DESCRIPTION
use ramda `R.isNil(value)` to check null or undefined
