### PR TITLE
Frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "noes": "^0.0.2",
     "ramda": "^0.21.0",
     "read-chunk": "^1.0.1",
-    "sprintf-js": "^1.0.3",
-    "validator": "^3.39.0"
+    "sprintf-js": "^1.0.3"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/sendyhalim/satpam",
   "dependencies": {
-    "file-type": "^3.8.0",
+    "file-type": "~3.8.0",
     "image-type": "^2.0.2",
-    "lodash": "^4.13.1",
-    "moment": "^2.10.6",
-    "noes": "^0.0.2",
+    "lodash": "~4.0.0",
+    "moment": "~2.8.1",
+    "noes": "~0.0.6",
     "ramda": "^0.21.0",
     "read-chunk": "^1.0.1",
-    "sprintf-js": "^1.0.3"
+    "sprintf-js": "~1.0.3"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -8,6 +8,8 @@ import alpha from './validators/alpha';
 import alphanumeric from './validators/alphanumeric';
 import date from './validators/date';
 import url from './validators/url';
+import ip from './validators/ip';
+import fqdn from './validators/fqdn';
 import string from './validators/string';
 import nonBlank from './validators/non-blank';
 import length from './validators/length';
@@ -39,6 +41,8 @@ let validation = {
   alphanumeric: alphanumeric.validate,
   date: date.validate,
   url: url.validate,
+  ip: ip.validate,
+  fqdn: fqdn.validate,
   string: string.validate,
   nonBlank: nonBlank.validate,
   creditCard: creditCard.validate,
@@ -71,6 +75,8 @@ let validationMessages = {
   alphanumeric: alphanumeric.message,
   date: date.message,
   url: url.message,
+  ip: ip.message,
+  fqdn: fqdn.message,
   string: string.message,
   nonBlank: nonBlank.message,
   creditCard: creditCard.message,
@@ -144,7 +150,7 @@ class Validator {
       // Property fullName is the generic full name of validation rule
       // e.g range:1:3 -> range:$1:$2, required -> required
       ruleObj.fullName = ruleObj.params.reduce((ruleName, val, index) => {
-        return ruleName + ':$' + (index + 1).toString();
+            return ruleName + ':$' + (index + 1).toString();
       }, ruleObj.name);
     }
 
@@ -171,8 +177,8 @@ class Validator {
 
     // Loop through the given rule mapping
     R.keys(ruleMapping).forEach(propertyName => {
-      const ruleArray = ruleMapping[propertyName];
-      const val = inputObj[propertyName];
+        const ruleArray = ruleMapping[propertyName];
+        const val = inputObj[propertyName];
 
       // Rule array should be something like ['required', 'email']
       ruleArray.forEach(rule => {
@@ -323,4 +329,5 @@ exports.setValidationMessage = (ruleName, message) => {
  */
 exports.validation = validation;
 
+// Expose satpam to window object, so it can be used in client side (browser)
 window.satpam = exports;

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,0 +1,326 @@
+import R from 'ramda';
+import _ from 'lodash';
+
+import required from './validators/required';
+import email from './validators/email';
+import numeric from './validators/numeric';
+import alpha from './validators/alpha';
+import alphanumeric from './validators/alphanumeric';
+import date from './validators/date';
+import url from './validators/url';
+import string from './validators/string';
+import nonBlank from './validators/non-blank';
+import length from './validators/length';
+import maxLength from './validators/max-length';
+import minLength from './validators/min-length';
+import minValue from './validators/min-value';
+import maxValue from './validators/max-value';
+import memberOf from './validators/member-of';
+import beginWith from './validators/begin-with';
+import regex from './validators/regex';
+import notEqual from './validators/not-equal';
+import equal from './validators/equal';
+import dateFormat from './validators/date-format';
+import dateAfter from './validators/date-after';
+import dateBefore from './validators/date-before';
+import creditCard from './validators/credit-card';
+import requiredIf from './validators/required-if';
+import taxId from './validators/tax-id';
+import phoneNumber from './validators/phone-number';
+import mobilePhoneNumber from './validators/mobile-phone-number';
+import mongoId from './validators/mongo-id';
+import minimumAge from './validators/minimum-age';
+
+let validation = {
+  required: required.validate,
+  numeric: numeric.validate,
+  email: email.validate,
+  alpha: alpha.validate,
+  alphanumeric: alphanumeric.validate,
+  date: date.validate,
+  url: url.validate,
+  string: string.validate,
+  nonBlank: nonBlank.validate,
+  creditCard: creditCard.validate,
+  mongoId: mongoId.validate,
+  phoneNumber: phoneNumber.validate,
+  mobilePhoneNumber: mobilePhoneNumber.validate,
+  'length:$1': length.validate,
+  'maxLength:$1': maxLength.validate,
+  'minLength:$1': minLength.validate,
+  'maxValue:$1': maxValue.validate,
+  'minValue:$1': minValue.validate,
+  'memberOf:$1': memberOf.validate,
+  'beginWith:$1': beginWith.validate,
+  'regex:$1:$2': regex.validate,
+  'not-equal:$1': notEqual.validate,
+  'equal:$1': equal.validate,
+  'dateFormat:$1': dateFormat.validate,
+  'dateAfter:$1:$2:$3:$4': dateAfter.validate,
+  'dateBefore:$1:$2:$3:$4': dateBefore.validate,
+  'requiredIf:$1:$2': requiredIf.validate,
+  'taxId:$1': taxId.validate,
+  'minimumAge:$1:$2': minimumAge.validate
+};
+
+let validationMessages = {
+  required: required.message,
+  numeric: numeric.message,
+  email: email.message,
+  alpha: alpha.message,
+  alphanumeric: alphanumeric.message,
+  date: date.message,
+  url: url.message,
+  string: string.message,
+  nonBlank: nonBlank.message,
+  creditCard: creditCard.message,
+  mongoId: mongoId.message,
+  phoneNumber: phoneNumber.message,
+  mobilePhoneNumber: mobilePhoneNumber.message,
+  'length:$1': length.message,
+  'maxValue:$1': maxValue.message,
+  'minValue:$1': minValue.message,
+  'maxLength:$1': maxLength.message,
+  'minLength:$1': minLength.message,
+  'memberOf:$1': memberOf.message,
+  'beginWith:$1': beginWith.message,
+  'regex:$1:$2': regex.message,
+  'not-equal:$1': notEqual.message,
+  'equal:$1': equal.message,
+  'dateFormat:$1': dateFormat.message,
+  'dateAfter:$1:$2:$3:$4': dateAfter.message,
+  'dateBefore:$1:$2:$3:$4': dateBefore.message,
+  'requiredIf:$1:$2': requiredIf.message,
+  'taxId:$1': taxId.message,
+  'minimumAge:$1:$2': minimumAge.message
+};
+
+class ValidationMessage {
+  constructor() {
+    this.messageArray = [];
+  }
+}
+
+/**
+ * Create a new validator. When it's created, it will have a deep cloned global
+ * validation rules and global validation messages. Any changes made to the
+ * instance's rules or messages will not affect the global validation rules
+ * and messages.
+ * @constructor
+ */
+class Validator {
+  constructor() {
+    this.validation = {
+      rules: R.clone(validation),
+      messages: R.clone(validationMessages)
+    };
+  }
+
+  /**
+   * Create a rule object based on the given rule.
+   * @param rule {Object|String}
+   * @returns {{name: String, fullName: String, params: Array<String>}}
+   */
+  _createRuleObject(rule) {
+    let ruleObj = {};
+
+    if (R.is(String, rule)) {
+      // First variant, everything is embedded as string
+      const splitted = rule.split(':');
+
+      // Get only the first part of full rule e.g if range:1:3 then
+      // we will get 'range'
+      ruleObj.name = R.head(splitted);
+      // Get the rule params if e.g range:1:3 -> [1, 3]
+      ruleObj.params = splitted.slice(1);
+    } else {
+      // Second variant, it is already parsed (Object)
+      ruleObj.name = rule.name;
+      ruleObj.fullName = rule.fullName;
+      ruleObj.params = rule.params || [];
+    }
+
+    if (!ruleObj.fullName) {
+      // Property fullName is the generic full name of validation rule
+      // e.g range:1:3 -> range:$1:$2, required -> required
+      ruleObj.fullName = ruleObj.params.reduce((ruleName, val, index) => {
+        return ruleName + ':$' + (index + 1).toString();
+      }, ruleObj.name);
+    }
+
+    return ruleObj;
+  }
+
+
+  /**
+   * @example
+   *   const ruleMapping = {name: ['required']};
+   *   const inputObj = {name: ''};
+   *   const validator = satpam.create();
+   *   const result = validator.validate(ruleMapping, inputObj);
+   *
+   * @param ruleMapping - An mapping of input property to the available rules
+   *   e.g. {name: ['required', 'alpha']}
+   * @param inputObj - Input object to be validated
+   * @returns {{result: Boolean, messages: Object}}
+   */
+  validate(ruleMapping, inputObj) {
+    const validator = this;
+    let result = true;
+    let messageObj = new ValidationMessage();
+
+    // Loop through the given rule mapping
+    R.keys(ruleMapping).forEach(propertyName => {
+      const ruleArray = ruleMapping[propertyName];
+      const val = inputObj[propertyName];
+
+      // Rule array should be something like ['required', 'email']
+      ruleArray.forEach(rule => {
+        const ruleObj = this._createRuleObject(rule);
+        const validate = validator.validation.rules[ruleObj.fullName];
+
+        if (!R.is(Function, validate)) {
+          const ruleObjString = JSON.stringify(ruleObj);
+          throw new Error(`${ruleObj.fullName} is not a valid satpam validation rule. Rule object: ${ruleObjString}`);
+        }
+
+        const validationResult = validate(val, ruleObj, propertyName, inputObj);
+
+        if (!validationResult) {
+          result = false;
+
+          // Set messageObj initial value
+          messageObj[propertyName] = messageObj[propertyName] || {};
+
+          // Set the validation message
+          const msg = validator.getValidationMessage(ruleObj, propertyName, val);
+          messageObj[propertyName][ruleObj.fullName] = msg;
+          messageObj.messageArray.push(msg);
+        }
+      });
+    });
+
+    return {
+      success: result,
+      messages: messageObj
+    };
+  }
+
+
+  /**
+   * @param ruleObj
+   * @param propertyName
+   * @param val
+   * @returns {String}
+   */
+  getValidationMessage(ruleObj, propertyName, val) {
+    const message = this.validation.messages[ruleObj.fullName];
+    const messageTemplate = R.is(Function, message) ? message(ruleObj, propertyName, val) : message;
+    const compiled = _.template(messageTemplate);
+    propertyName = _.startCase(propertyName);
+
+    return compiled({
+      propertyName: propertyName,
+      ruleName: ruleObj.fullName,
+      ruleParams: ruleObj.params,
+      value: val
+    });
+  }
+
+
+  /**
+   * Add custom validation the validator instance, it will only affect the
+   * validator instance, if you want to add global validation rule then use
+   * addCustomValidation method on satpam module.
+   *
+   * @example
+   *   import satpam from 'satpam';
+   *   satpam.addCustomValidation(.., ..);
+   *
+   * @param ruleName
+   * @param validationFunction
+   */
+  addCustomValidation(ruleName, validateFunction) {
+    this.validation.rules[ruleName] = validateFunction;
+  }
+
+  /**
+   * Set validation message for the given ruleName, it will only affect the
+   * validator instance(the receiver), if you want to set global validation
+   * message then use addCustomValidation method on satpam module.
+   *
+   * @example
+   *   import satpam from 'satpam';
+   *   satpam.setValidationMessage(.., ..);
+   *
+   * @param ruleName
+   * @param message
+   */
+  setValidationMessage(ruleName, message) {
+    this.validation.messages[ruleName] = message;
+  }
+}
+
+/**
+ * Create new Validator instance, will have validations and validation messages
+ * that is cloned from the global validations and validation messages.
+ * @returns Validator - Satpam validator instance
+ */
+exports.create = () => new Validator();
+
+/**
+ * @example
+ *   const ruleMapping = {name: ['required']};
+ *   const inputObj = {name: ''};
+ *   const validator = satpam.create();
+ *   const result = validator.validate(ruleMapping, inputObj);
+ *
+ * @param ruleMapping - An mapping of input property to the available rules
+ *   e.g. {name: ['required', 'alpha']}
+ * @param inputObj - Input object to be validated
+ * @returns {{result: Boolean, messages: Object}}
+ */
+exports.validate = (ruleMapping, inputObj) => {
+  const validator = new Validator();
+  return validator.validate(ruleMapping, inputObj);
+};
+
+/**
+ * Add custom validation the validator instance, it will only affect the
+ * validator instance, if you want to add global validation rule then use
+ * addCustomValidation method on satpam module.
+ *
+ * @example
+ *   import satpam from 'satpam';
+ *   satpam.addCustomValidation(.., ..);
+ *
+ * @param ruleName
+ * @param validationFunction
+ */
+exports.addCustomValidation = (ruleName, validationFunction) => {
+  validation[ruleName] = validationFunction;
+};
+
+/**
+ * Set validation message for the given ruleName, it will only affect the
+ * validator instance(the receiver), if you want to set global validation
+ * message then use addCustomValidation method on satpam module.
+ *
+ * @example
+ *   import satpam from 'satpam';
+ *   satpam.setValidationMessage(.., ..);
+ *
+ * @param ruleName
+ * @param message
+ */
+exports.setValidationMessage = (ruleName, message) => {
+  validationMessages[ruleName] = message;
+};
+
+/**
+ * The global validation object that contains all of the validation rules
+ * @type {object}
+ */
+exports.validation = validation;
+
+window.satpam = exports;

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -359,3 +359,6 @@ exports.setValidationMessage = (ruleName, message) => {
  * @type {object}
  */
 exports.validation = validation;
+
+// Expose satpam to window object so it can be used in client side (browser environment)
+window.satpam = exports;

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -105,7 +105,7 @@ class ValidationMessage {
   constructor() {
     this.messageArray = [];
   }
-  }
+}
 
   /**
    * Create a new validator. When it's created, it will have a deep cloned global

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import alpha from './validators/alpha';
 import alphanumeric from './validators/alphanumeric';
 import date from './validators/date';
 import url from './validators/url';
+import ip from './validators/ip';
+import fqdn from './validators/fqdn';
 import string from './validators/string';
 import nonBlank from './validators/non-blank';
 import length from './validators/length';
@@ -42,6 +44,8 @@ let validation = {
   alphanumeric: alphanumeric.validate,
   date: date.validate,
   url: url.validate,
+  ip: ip.validate,
+  fqdn: fqdn.validate,
   string: string.validate,
   nonBlank: nonBlank.validate,
   creditCard: creditCard.validate,
@@ -76,6 +80,8 @@ let validationMessages = {
   alphanumeric: alphanumeric.message,
   date: date.message,
   url: url.message,
+  ip: ip.message,
+  fqdn: fqdn.message,
   string: string.message,
   nonBlank: nonBlank.message,
   creditCard: creditCard.message,

--- a/src/validators/alpha.js
+++ b/src/validators/alpha.js
@@ -1,8 +1,8 @@
-import validator from 'validator';
+var alphaRegex = /^[A-Z]+$/i;
 
 const validate = val => {
   if (val) {
-    return validator.isAlpha(val);
+    return alphaRegex.test(val);
   }
 
   return true;

--- a/src/validators/alpha.js
+++ b/src/validators/alpha.js
@@ -1,4 +1,4 @@
-var alphaRegex = /^[A-Z]+$/i;
+const alphaRegex = /^[A-Z]+$/i;
 
 const validate = val => {
   if (val) {

--- a/src/validators/alphanumeric.js
+++ b/src/validators/alphanumeric.js
@@ -1,8 +1,8 @@
-import validator from 'validator';
+var alphanumericRegex = /^[0-9A-Z]+$/i;
 
 const validate = val => {
   if (val) {
-    return validator.isAlphanumeric(val);
+    return alphanumericRegex.test(val);
   }
 
   return true;

--- a/src/validators/alphanumeric.js
+++ b/src/validators/alphanumeric.js
@@ -1,4 +1,4 @@
-var alphanumericRegex = /^[0-9A-Z]+$/i;
+const alphanumericRegex = /^[0-9A-Z]+$/i;
 
 const validate = val => {
   if (val) {

--- a/src/validators/date.js
+++ b/src/validators/date.js
@@ -1,8 +1,8 @@
-import validator from 'validator';
+import moment from 'moment';
 
 const validate = val => {
   if (val) {
-    return validator.isDate(val);
+    return moment(val).isValid();
   }
 
   return true;

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -6,7 +6,7 @@
  * @returns {Boolean}
  */
 
-var emailUserUtf8Regex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))$/i;
+const emailUserUtf8Regex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))$/i;
 import fqdn from './fqdn';
 
 const validate = val => {

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -25,7 +25,6 @@ const validate = val => {
     if (lowerDomain === 'gmail.com' || lowerDomain === 'googlemail.com') {
       user = user.replace(/\./g, '').toLowerCase();
     }
-    console.log(domain);
     if (!fqdn.validate(domain)) {
       return false;
     }

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -10,29 +10,29 @@ var emailUserUtf8Regex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD
 import fqdn from './fqdn';
 
 const validate = val => {
-  if (val) {
-    if (/\s/.test(val)) {
-      return false;
-    }
-
-    var parts = val.split('@');
-    var domain = parts.pop();
-    var user = parts.join('@');
-
-    var lowerDomain = domain.toLowerCase();
-    // Google mail ignore dot in email user, so foo.bar will be same as foobar
-    // Read: http://webapps.stackexchange.com/questions/14668/why-does-google-not-consider-dot-in-usernames-of-gmail-addresses
-    if (lowerDomain === 'gmail.com' || lowerDomain === 'googlemail.com') {
-      user = user.replace(/\./g, '').toLowerCase();
-    }
-    if (!fqdn.validate(domain)) {
-      return false;
-    }
-
-    return emailUserUtf8Regex.test(user);
+  if (!val) {
+    return true;
   }
 
-  return true;
+  if (/\s/.test(val)) {
+    return false;
+  }
+
+  var parts = val.split('@');
+  var domain = parts.pop();
+  var user = parts.join('@');
+
+  var lowerDomain = domain.toLowerCase();
+  // Google mail ignore dot in email user, so foo.bar will be same as foobar
+  // Read: http://webapps.stackexchange.com/questions/14668/why-does-google-not-consider-dot-in-usernames-of-gmail-addresses
+  if (lowerDomain === 'gmail.com' || lowerDomain === 'googlemail.com') {
+    user = user.replace(/\./g, '').toLowerCase();
+  }
+  if (!fqdn.validate(domain)) {
+    return false;
+  }
+
+  return emailUserUtf8Regex.test(user);
 };
 
 const message = '<%= propertyName %> must be email.';

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -1,8 +1,36 @@
-import validator from 'validator';
+/**
+ * Validate email
+ * This is a modified version of github.com/chriso/validator.js `isEmail`
+ *
+ * @param val
+ * @returns {Boolean}
+ */
+
+var emailUserUtf8Regex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))$/i;
+import fqdn from './fqdn';
 
 const validate = val => {
   if (val) {
-    return validator.isEmail(val);
+    if (/\s/.test(val)) {
+      return false;
+    }
+
+    var parts = val.split('@');
+    var domain = parts.pop();
+    var user = parts.join('@');
+
+    var lowerDomain = domain.toLowerCase();
+    // Google mail ignore dot in email user, so foo.bar will be same as foobar
+    // Read: http://webapps.stackexchange.com/questions/14668/why-does-google-not-consider-dot-in-usernames-of-gmail-addresses
+    if (lowerDomain === 'gmail.com' || lowerDomain === 'googlemail.com') {
+      user = user.replace(/\./g, '').toLowerCase();
+    }
+    console.log(domain);
+    if (!fqdn.validate(domain)) {
+      return false;
+    }
+
+    return emailUserUtf8Regex.test(user);
   }
 
   return true;

--- a/src/validators/fqdn.js
+++ b/src/validators/fqdn.js
@@ -1,0 +1,27 @@
+const validate = val => {
+  if (val) {
+    var parts = val.split('.');
+    var tld = parts.pop();
+
+    if (!parts.length || !/^([a-z\u00a1-\uffff]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+      return false;
+    }
+
+    for (var part, i = 0; i < parts.length; i++) {
+      part = parts[i];
+      if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) {
+        return false;
+      }
+      if (part[0] === '-' || part[part.length - 1] === '-' ||
+        part.indexOf('---') >= 0) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const message = '<%= propertyName %> is not a valid FQDN.';
+
+export default {validate, message};

--- a/src/validators/fqdn.js
+++ b/src/validators/fqdn.js
@@ -1,25 +1,25 @@
 const validate = val => {
-  if (val) {
-    var parts = val.split('.');
-    var tld = parts.pop();
-
-    if (!parts.length || !/^([a-z\u00a1-\uffff]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
-      return false;
-    }
-
-    for (var part, i = 0; i < parts.length; i++) {
-      part = parts[i];
-      if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) {
-        return false;
-      }
-      if (part[0] === '-' || part[part.length - 1] === '-' ||
-        part.indexOf('---') >= 0) {
-        return false;
-      }
-    }
+  if (!val) {
+    return true;
   }
 
-  return true;
+  var parts = val.split('.');
+  var tld = parts.pop();
+
+  if (!parts.length || !/^([a-z\u00a1-\uffff]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+    return false;
+  }
+
+  for (var part, i = 0; i < parts.length; i++) {
+    part = parts[i];
+    if (!/^[a-z\u00a1-\uffff0-9-]+$/i.test(part)) {
+      return false;
+    }
+    if (part[0] === '-' || part[part.length - 1] === '-' ||
+      part.indexOf('---') >= 0) {
+      return false;
+    }
+  }
 };
 
 const message = '<%= propertyName %> is not a valid FQDN.';

--- a/src/validators/fqdn.js
+++ b/src/validators/fqdn.js
@@ -20,6 +20,8 @@ const validate = val => {
       return false;
     }
   }
+
+  return true;
 };
 
 const message = '<%= propertyName %> is not a valid FQDN.';

--- a/src/validators/ip.js
+++ b/src/validators/ip.js
@@ -1,0 +1,88 @@
+/**
+ * Validate IPv4
+ * This is a modified version of github.com/chriso/validator.js `isIP` (version === 4)
+ *
+ * @param val
+ * @returns {Boolean}
+ */
+function isIPv4(val) {
+  // It will accept anything with three dots (.) and numeric digits
+  var ipv4Regex = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/;
+  if (!ipv4Regex.test(val)) {
+    return false;
+  }
+  // This part of code do checking for any invalid IP address like 256.256.256.256
+  var parts = val.split('.').sort(function (a, b) {
+    return a - b;
+  });
+  return parts[3] <= 255;
+}
+
+/**
+ * Validate IPv6
+ * This is a modified version of github.com/chriso/validator.js `isIP` (version === 6)
+ *
+ * @param val
+ * @returns {Boolean}
+ */
+function isIPv6(val) {
+  var ipv6Block = /^[0-9A-F]{1,4}$/i;
+  var blocks = val.split(':');
+  var foundOmissionBlock = false; // marker to indicate ::
+
+  // At least some OS accept the last 32 bits of an IPv6 address
+  // (i.e. 2 of the blocks) in IPv4 notation, and RFC 3493 says
+  // that '::ffff:a.b.c.d' is valid for IPv4-mapped IPv6 addresses,
+  // and '::a.b.c.d' is deprecated, but also valid.
+  var foundIPv4TransitionBlock = isIPv4(blocks[blocks.length - 1]);
+  var expectedNumberOfBlocks = foundIPv4TransitionBlock ? 7 : 8;
+
+  if (blocks.length > expectedNumberOfBlocks)
+    return false;
+
+  // initial or final ::
+  if (val === '::') {
+    return true;
+  } else if (val.substr(0, 2) === '::') {
+    blocks.shift();
+    blocks.shift();
+    foundOmissionBlock = true;
+  } else if (val.substr(val.length - 2) === '::') {
+    blocks.pop();
+    blocks.pop();
+    foundOmissionBlock = true;
+  }
+
+  for (var i = 0; i < blocks.length; ++i) {
+    // test for a :: which can not be at the string start/end
+    // since those cases have been handled above
+    if (blocks[i] === '' && i > 0 && i < blocks.length -1) {
+      if (foundOmissionBlock)
+        return false; // multiple :: in address
+      foundOmissionBlock = true;
+    } else if (foundIPv4TransitionBlock && i == blocks.length - 1) {
+      // it has been checked before that the last
+      // block is a valid IPv4 address
+    } else if (!ipv6Block.test(blocks[i])) {
+      return false;
+    }
+  }
+
+  if (foundOmissionBlock) {
+    return blocks.length >= 1;
+  }
+  return blocks.length === expectedNumberOfBlocks;
+}
+
+const validate = val => {
+  if (!val) {
+    return true;
+  }
+
+  return isIPv4(val) || isIPv6(val);
+};
+
+const message = '<%= propertyName %> is not a valid IP address.';
+
+export default {validate, message};
+

--- a/src/validators/ip.js
+++ b/src/validators/ip.js
@@ -7,7 +7,7 @@
  */
 function isIPv4(val) {
   // It will accept anything with three dots (.) and numeric digits
-  var ipv4Regex = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/;
+  const ipv4Regex = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/;
   if (!ipv4Regex.test(val)) {
     return false;
   }
@@ -26,7 +26,7 @@ function isIPv4(val) {
  * @returns {Boolean}
  */
 function isIPv6(val) {
-  var ipv6Block = /^[0-9A-F]{1,4}$/i;
+  const ipv6Block = /^[0-9A-F]{1,4}$/i;
   var blocks = val.split(':');
   var foundOmissionBlock = false; // marker to indicate ::
 

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -1,8 +1,8 @@
-import validator from 'validator';
+var numericRegex = /^[-+]?[0-9]+$/;
 
 const validate = val => {
   if (val) {
-    return validator.isNumeric(val);
+    numericRegex.test(val);
   }
 
   return true;

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -2,7 +2,7 @@ var numericRegex = /^[-+]?[0-9]+$/;
 
 const validate = val => {
   if (val) {
-    numericRegex.test(val);
+    return numericRegex.test(val);
   }
 
   return true;

--- a/src/validators/numeric.js
+++ b/src/validators/numeric.js
@@ -1,4 +1,4 @@
-var numericRegex = /^[-+]?[0-9]+$/;
+const numericRegex = /^[-+]?[0-9]+$/;
 
 const validate = val => {
   if (val) {

--- a/src/validators/url.js
+++ b/src/validators/url.js
@@ -15,9 +15,10 @@ const validate = val => {
   }
 
   // Check length
-  if (!val || val.length >= 2083 || /\s/.test(val)) {
+  if (val.length >= 2083 || /\s/.test(val)) {
     return false;
   }
+
   // Check for mailto: (it's email address not an url!)
   if (val.indexOf('mailto:') === 0) {
     return false;

--- a/src/validators/url.js
+++ b/src/validators/url.js
@@ -1,11 +1,72 @@
-import validator from 'validator';
+/**
+ * Validate url
+ * This is a modified version of github.com/chriso/validator.js `isUrl`,
+ *
+ * @param val
+ * @returns {Boolean}
+ */
+
+import ip from './ip';
+import fqdn from './fqdn';
 
 const validate = val => {
   if (!val) {
     return true;
   }
 
-  return validator.isURL(val);
+  // Check length
+  if (!val || val.length >= 2083 || /\s/.test(val)) {
+    return false;
+  }
+  // Check for mailto: (it's email address not an url!)
+  if (val.indexOf('mailto:') === 0) {
+    return false;
+  }
+
+  var split = val.split('://');
+
+  // Check protocol (only allow 'http', 'https', 'ftp')
+  if (split.length > 1) {
+    var protocols = ['http', 'https', 'ftp'];
+    var protocol = split.shift();
+    if (protocols.indexOf(protocol) === -1) {
+      return false;
+    }
+  }
+
+  val = split.join('://');
+  split = val.split('#');
+  val = split.shift();
+
+  split = val.split('?');
+  val = split.shift();
+
+  split = val.split('/');
+  val = split.shift();
+  split = val.split('@');
+
+  if (split.length > 1) {
+    var auth = split.shift();
+    if (auth.indexOf(':') >= 0 && auth.split(':').length > 2) {
+      return false;
+    }
+  }
+
+  var hostname = split.join('@');
+  split = hostname.split(':');
+  var host = split.shift();
+
+  // Check for url port (port must be a number range from 0 to 65535)
+  if (split.length) {
+    var port_str = split.join(':');
+    var port = parseInt(port_str, 10);
+    if (!/^[0-9]+$/.test(port_str) || port <= 0 || port > 65535) {
+      return false;
+    }
+  }
+
+  // Check for host, it can be an IP address (IPv4 or IPv6), FQDN (Fully Qualified Domain Name), or 'localhost'
+  return ip.validate(host) || fqdn.validate(host) || host === 'localhost';
 };
 
 const message = '<%= propertyName %> is not a valid url.';

--- a/test/validators/fqdn.spec.js
+++ b/test/validators/fqdn.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('FQDN validator', () => {
+  const rules = {
+    addr: ['fqdn']
+  };
+
+  it('should success', () => {
+    const result = validator.validate(rules, {addr: 'foo.com'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('addr');
+  });
+
+
+  it('should fail', () => {
+    const result = validator.validate(rules, {addr: 'f!oo.bar'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('addr');
+    expect(err.addr.fqdn).to.equal('Addr is not a valid FQDN.');
+  });
+});

--- a/test/validators/ip.spec.js
+++ b/test/validators/ip.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('IP address validator', () => {
+  const rules = {
+    ipaddr: ['ip']
+  };
+
+  it('should success on valid IPv4 address', () => {
+    const result = validator.validate(rules, {ipaddr: '216.58.212.142'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('ipaddr');
+  });
+
+  it('should success on valid IPv6 address', () => {
+    const result = validator.validate(rules, {ipaddr: '2001:db8:0000:1:1:1:1:1'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('ipaddr');
+  });
+
+  it('should fail on invalid IPv4 address (more than 255)', () => {
+    const result = validator.validate(rules, {ipaddr: '1.1.1.256'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('ipaddr');
+    expect(err.ipaddr.ip).to.equal('Ipaddr is not a valid IP address.');
+  });
+
+  it('should fail on invalid IPv6 address', () => {
+    const result = validator.validate(rules, {ipaddr: '2001:db8:0000:1:1:1:1::1'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('ipaddr');
+    expect(err.ipaddr.ip).to.equal('Ipaddr is not a valid IP address.');
+  });
+});

--- a/test/validators/url.spec.js
+++ b/test/validators/url.spec.js
@@ -14,6 +14,23 @@ describe('Url validator', () => {
     expect(err).to.not.have.property('website');
   });
 
+  it('should success on valid IPv4 address', () => {
+    const result = validator.validate(rules, {website: '216.58.212.142'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('website');
+  });
+
+  it('should fail on invalid IPv4 address (more than 255)', () => {
+    const result = validator.validate(rules, {website: '1.1.1.256'});
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('website');
+    expect(err.website.url).to.equal('Website is not a valid url.');
+  });
+
   it('should fail', () => {
     const result = validator.validate(rules, {website: 'https:/\wikipedia.org'});
     const err = result.messages;

--- a/test/validators/url.spec.js
+++ b/test/validators/url.spec.js
@@ -14,23 +14,6 @@ describe('Url validator', () => {
     expect(err).to.not.have.property('website');
   });
 
-  it('should success on valid IPv4 address', () => {
-    const result = validator.validate(rules, {website: '216.58.212.142'});
-    const err = result.messages;
-
-    expect(result.success).to.equal(true);
-    expect(err).to.not.have.property('website');
-  });
-
-  it('should fail on invalid IPv4 address (more than 255)', () => {
-    const result = validator.validate(rules, {website: '1.1.1.256'});
-    const err = result.messages;
-
-    expect(result.success).to.equal(false);
-    expect(err).to.have.property('website');
-    expect(err.website.url).to.equal('Website is not a valid url.');
-  });
-
   it('should fail', () => {
     const result = validator.validate(rules, {website: 'https:/\wikipedia.org'});
     const err = result.messages;


### PR DESCRIPTION
We would like to use satpam in client-side (browser), so I create new file `frontend.js`, basically a copy of `index.js` but strip some functionality of satpam (`frontend.js` exclude validation for `image` & `file-type`). By doing this, satpam can be used in browser environment.

After a discussion with @sendyhalim, we decided to remove `validator.js` deps, because it has some problem when compiled with webpack. This issue may tell us what the problem is. https://github.com/webpack/webpack/issues/706.

I do copying and modifiying some of `validator.js` codes (on `isEmail` & `isUrl`) and add `ip` (IPv4 & IPv6 address validator) & `fqdn` (Fully Qualified Domain Name https://en.wikipedia.org/wiki/Fully_qualified_domain_name) to satpam validator (because they are used in `isUrl`).

I downgraded some depedencies in `package.json` so they match with current deps version in Cermati, so webpack will not requiring duplicate package with different version. It may help to minimize satpam library size for faster javascript load.
