### PR TITLE
Add ability to define nested rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ if (result.success === true) {
   // invalid
   result.messages.officeEmail.email === 'OfficeEmail must be email';
   result.messages.phone.number === 'Phone must be numeric';
-
-  // or get all messages in array form
-  result.messages.messageArray[0] = 'OfficeEmail must be email';
-  result.messages.messageArray[1] = 'Phone must be numeric';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ import satpam from 'satpam';
 
 const rules = {
   name: ['required'],
-  officeEmail: ['email'],
-  phone: ['required', 'numeric']
+  phone: ['required', 'numeric'],
+  email: ['required', 'email']
+  office: {
+    secondaryEmail: ['email'],
+  }
 };
 
 const input = {
   name: 'Sendy',
   title: 'Lord',
-  officeEmail: 'invalid email',
-  phone: 'hi there123'
+  phone: 'hi there123',
+  email: 'test@example.com',
+  office: {
+    secondaryEmail: 'invalid email',
+  }
 };
 
 const result = satpam.validate(rules, input);
@@ -36,8 +42,8 @@ if (result.success === true) {
   // valid
 } else {
   // invalid
-  result.messages.officeEmail.email === 'OfficeEmail must be email';
-  result.messages.phone.number === 'Phone must be numeric';
+  result.messages.office.secondaryEmail.email === 'Secondary Email must be email.';
+  result.messages.phone.number === 'Phone must be numeric.';
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "0.4.4",
+  "version": "1.0.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -105,50 +105,50 @@ class ValidationMessage {
   constructor() { }
 }
 
+/**
+ * Create a new validator. When it's created, it will have a deep cloned global
+ * validation rules and global validation messages. Any changes made to the
+ * instance's rules or messages will not affect the global validation rules
+ * and messages.
+ * @constructor
+ */
+class Validator {
+  constructor() {
+    this.validation = {
+      rules: R.clone(validation),
+      messages: R.clone(validationMessages)
+    };
+  }
+
   /**
-   * Create a new validator. When it's created, it will have a deep cloned global
-   * validation rules and global validation messages. Any changes made to the
-   * instance's rules or messages will not affect the global validation rules
-   * and messages.
-   * @constructor
+   * Create a rule object based on the given rule.
+   * @param rule {Object|String}
+   * @returns {{name: String, fullName: String, params: Array<String>}}
    */
-  class Validator {
-    constructor() {
-      this.validation = {
-        rules: R.clone(validation),
-        messages: R.clone(validationMessages)
-      };
+  _createRuleObject(rule) {
+    let ruleObj = {};
+
+    if (R.is(String, rule)) {
+      // First variant, everything is embedded as string
+      const splitted = rule.split(':');
+
+      // Get only the first part of full rule e.g if range:1:3 then
+      // we will get 'range'
+      ruleObj.name = R.head(splitted);
+      // Get the rule params if e.g range:1:3 -> [1, 3]
+      ruleObj.params = splitted.slice(1);
+    } else {
+      // Second variant, it is already parsed (Object)
+      ruleObj.name = rule.name;
+      ruleObj.fullName = rule.fullName;
+      ruleObj.params = rule.params || [];
     }
 
-    /**
-     * Create a rule object based on the given rule.
-     * @param rule {Object|String}
-     * @returns {{name: String, fullName: String, params: Array<String>}}
-     */
-    _createRuleObject(rule) {
-      let ruleObj = {};
-
-      if (R.is(String, rule)) {
-        // First variant, everything is embedded as string
-        const splitted = rule.split(':');
-
-        // Get only the first part of full rule e.g if range:1:3 then
-        // we will get 'range'
-        ruleObj.name = R.head(splitted);
-        // Get the rule params if e.g range:1:3 -> [1, 3]
-        ruleObj.params = splitted.slice(1);
-      } else {
-        // Second variant, it is already parsed (Object)
-        ruleObj.name = rule.name;
-        ruleObj.fullName = rule.fullName;
-        ruleObj.params = rule.params || [];
-      }
-
-      if (!ruleObj.fullName) {
-        // Property fullName is the generic full name of validation rule
-        // e.g range:1:3 -> range:$1:$2, required -> required
-        ruleObj.fullName = ruleObj.params.reduce((ruleName, val, index) => {
-            return ruleName + ':$' + (index + 1).toString();
+    if (!ruleObj.fullName) {
+      // Property fullName is the generic full name of validation rule
+      // e.g range:1:3 -> range:$1:$2, required -> required
+      ruleObj.fullName = ruleObj.params.reduce((ruleName, val, index) => {
+        return ruleName + ':$' + (index + 1).toString();
       }, ruleObj.name);
     }
 
@@ -176,124 +176,132 @@ class ValidationMessage {
     // Loop through the given rule mapping
     R.keys(ruleMapping).forEach(propertyName => {
       const ruleArray = ruleMapping[propertyName];
-      const val = inputObj[propertyName];
+      const val = _.get(inputObj, propertyName);
       const setValidationMessage = (ruleName, message) => {
-      // Set messageObj initial value
-      messageObj[propertyName] = messageObj[propertyName] || {};
-      messageObj[propertyName][ruleName] = message;
-      messageObj.messageArray.push(message);
-    };
-
-    const _validate = rule => {
-      const ruleObj = this._createRuleObject(rule);
-      const validate = validator.validation.rules[ruleObj.fullName];
-
-      if (!R.is(Function, validate)) {
-        const ruleObjString = JSON.stringify(ruleObj);
-        throw new Error(`${ruleObj.fullName} is not a valid satpam validation rule. Rule object: ${ruleObjString}`);
-      }
-
-      const validationResult = validate(val, ruleObj, propertyName, inputObj);
-
-      if (!validationResult) {
-        return {
-          success: false,
-          ruleName: ruleObj.fullName,
-          message: validator.getValidationMessage(ruleObj, propertyName, val)
-        }
-      }
-
-      return {
-        success: true,
-        ruleName: ruleObj.fullName,
-        message: ''
+        // Set messageObj initial value
+        messageObj[propertyName] = messageObj[propertyName] || {};
+        messageObj[propertyName][ruleName] = message;
       };
-    };
 
-    // Rule array should be something like ['required', 'email']
-    ruleArray.forEach(rule => {
-      // We will validate and return true if any of the rule passes
-      if (R.is(Array, rule)) {
-        const resultObjects = rule.map(_validate);
-        const overallResult = R.any(R.prop('success'), resultObjects);
+      const _validate = rule => {
+        const ruleObj = this._createRuleObject(rule);
+        const validate = validator.validation.rules[ruleObj.fullName];
 
-        // If none of the results is true then it
-        if (!overallResult) {
-          result = false;
-            resultObjects.forEach(resultObj => {
-              setValidationMessage(resultObj.ruleName, resultObj.message);
-          });
+        if (!R.is(Function, validate)) {
+          const ruleObjString = JSON.stringify(ruleObj);
+          throw new Error(`${ruleObj.fullName} is not a valid satpam validation rule. Rule object: ${ruleObjString}`);
         }
+
+        const validationResult = validate(val, ruleObj, propertyName, inputObj);
+
+        if (!validationResult) {
+          return {
+            success: false,
+            ruleName: ruleObj.fullName,
+            message: validator.getValidationMessage(ruleObj, propertyName, val)
+          }
+        }
+
+        return {
+          success: true,
+          ruleName: ruleObj.fullName,
+          message: ''
+        };
+      };
+
+      // Nested rule
+      if (!_.isArray(ruleArray)) {
+        const nestedResult = this.validate(ruleArray, _.get(inputObj, propertyName));
+        result = nestedResult.success && result;
+
+        // Merge the result
+        messageObj[propertyName] = nestedResult.messages;
       } else {
-        const resultObj = _validate(rule);
+        // Rule array should be something like ['required', 'email']
+        ruleArray.forEach(rule => {
+          // We will validate and return true if any of the rule passes
+          if (R.is(Array, rule)) {
+            const resultObjects = rule.map(_validate);
+            const overallResult = R.any(R.prop('success'), resultObjects);
 
-        if (!resultObj.success) {
-          result = false;
-          setValidationMessage(resultObj.ruleName, resultObj.message);
-        }
+            // If none of the results is true then it
+            if (!overallResult) {
+              result = false;
+              resultObjects.forEach(resultObj => {
+                setValidationMessage(resultObj.ruleName, resultObj.message);
+              });
+            }
+          } else {
+            const resultObj = _validate(rule);
+
+            if (!resultObj.success) {
+              result = false;
+              setValidationMessage(resultObj.ruleName, resultObj.message);
+            }
+          }
+        });
+
       }
     });
-  });
 
-  return {
-    success: result,
-    messages: messageObj
-  };
-}
+    return {
+      success: result,
+      messages: messageObj
+    };
+  }
 
+  /**
+   * @param ruleObj
+   * @param propertyName
+   * @param val
+   * @returns {String}
+   */
+  getValidationMessage(ruleObj, propertyName, val) {
+    const message = this.validation.messages[ruleObj.fullName];
+    const messageTemplate = R.is(Function, message) ? message(ruleObj, propertyName, val) : message;
+    const compiled = _.template(messageTemplate);
+    propertyName = _.startCase(propertyName);
 
-/**
- * @param ruleObj
- * @param propertyName
- * @param val
- * @returns {String}
- */
-getValidationMessage(ruleObj, propertyName, val) {
-  const message = this.validation.messages[ruleObj.fullName];
-  const messageTemplate = R.is(Function, message) ? message(ruleObj, propertyName, val) : message;
-  const compiled = _.template(messageTemplate);
-  propertyName = _.startCase(propertyName);
-
-  return compiled({
-    propertyName: propertyName,
-    ruleName: ruleObj.fullName,
-    ruleParams: ruleObj.params,
-    value: val
-  });
-}
+    return compiled({
+      propertyName: propertyName,
+      ruleName: ruleObj.fullName,
+      ruleParams: ruleObj.params,
+      value: val
+    });
+  }
 
 
-/**
- * Add custom validation the validator instance, it will only affect the
- * validator instance, if you want to add global validation rule then use
- * addCustomValidation method on satpam module.
- *
- * @example
- *   import satpam from 'satpam';
- *   satpam.addCustomValidation(.., ..);
- *
- * @param ruleName
- * @param validationFunction
- */
-addCustomValidation(ruleName, validateFunction) {
-  this.validation.rules[ruleName] = validateFunction;
-}
+  /**
+   * Add custom validation the validator instance, it will only affect the
+   * validator instance, if you want to add global validation rule then use
+   * addCustomValidation method on satpam module.
+   *
+   * @example
+   *   import satpam from 'satpam';
+   *   satpam.addCustomValidation(.., ..);
+   *
+   * @param ruleName
+   * @param validationFunction
+   */
+  addCustomValidation(ruleName, validateFunction) {
+    this.validation.rules[ruleName] = validateFunction;
+  }
 
-/**
- * Set validation message for the given ruleName, it will only affect the
- * validator instance(the receiver), if you want to set global validation
- * message then use addCustomValidation method on satpam module.
- *
- * @example
- *   import satpam from 'satpam';
- *   satpam.setValidationMessage(.., ..);
- *
- * @param ruleName
- * @param message
- */
-setValidationMessage(ruleName, message) {
-  this.validation.messages[ruleName] = message;
-}
+  /**
+   * Set validation message for the given ruleName, it will only affect the
+   * validator instance(the receiver), if you want to set global validation
+   * message then use addCustomValidation method on satpam module.
+   *
+   * @example
+   *   import satpam from 'satpam';
+   *   satpam.setValidationMessage(.., ..);
+   *
+   * @param ruleName
+   * @param message
+   */
+  setValidationMessage(ruleName, message) {
+    this.validation.messages[ruleName] = message;
+  }
 }
 
 /**

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -102,9 +102,7 @@ let validationMessages = {
 };
 
 class ValidationMessage {
-  constructor() {
-    this.messageArray = [];
-  }
+  constructor() { }
 }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -111,9 +111,7 @@ let validationMessages = {
 };
 
 class ValidationMessage {
-  constructor() {
-    this.messageArray = [];
-  }
+  constructor() { }
 }
 
 /**
@@ -187,12 +185,11 @@ class Validator {
     // Loop through the given rule mapping
     R.keys(ruleMapping).forEach(propertyName => {
       const ruleArray = ruleMapping[propertyName];
-      const val = inputObj[propertyName];
+      const val = _.get(inputObj, propertyName);
       const setValidationMessage = (ruleName, message) => {
         // Set messageObj initial value
         messageObj[propertyName] = messageObj[propertyName] || {};
         messageObj[propertyName][ruleName] = message;
-        messageObj.messageArray.push(message);
       };
 
       const _validate = rule => {
@@ -223,7 +220,7 @@ class Validator {
 
       // Nested rule
       if (!_.isArray(ruleArray)) {
-        const nestedResult = this.validate(ruleArray, inputObj[propertyName]);
+        const nestedResult = this.validate(ruleArray, _.get(inputObj, propertyName));
         result = nestedResult.success && result;
 
         // Merge the result

--- a/test/custom-validation-messages.spec.js
+++ b/test/custom-validation-messages.spec.js
@@ -10,10 +10,6 @@ describe('Validator.setValidationMessage()', () => {
     validator.setValidationMessage('minLength:$1', 'yo watt');
     const result = validator.validate(rule, {name: 'a'});
 
-    it('should return correct validation message array', () => {
-      expect(result.messages.messageArray).to.deep.equal(['yo watt']);
-    });
-
     it('should return correct validation message', () => {
       expect(result.messages.name['minLength:$1']).to.equal('yo watt');
     });
@@ -36,10 +32,6 @@ describe('Validator.setValidationMessage()', () => {
 
     const result = validator.validate(rule, {name: 'wubwub'});
     const expected = 'name: minLength, fullName: minLength:$1, params: 20, propertyName: name, value: wubwub';
-
-    it('should return correct validation message array', () => {
-      expect(result.messages.messageArray).to.deep.equal([expected]);
-    });
 
     it('should return correct validation message', () => {
       expect(result.messages.name['minLength:$1']).to.equal(expected);

--- a/test/validator-wrapper/validate.spec.js
+++ b/test/validator-wrapper/validate.spec.js
@@ -246,5 +246,53 @@ describe('Validator.validate()', () => {
       expect(err.office).to.not.have.property('emailOptional');
     });
   });
+
+  context('when given 2 level nested validation rules', () => {
+    const rules = {
+      name: ['required'],
+      nested: {
+        office: {
+          email: ['required', 'email'],
+          emailOptional: ['email']
+        }
+      }
+    };
+
+    it('should fail', () => {
+      const result = satpam.validate(rules, {
+        name: 'sendy',
+        office: {}
+      });
+      const err = result.messages;
+
+      expect(result.success).to.be.false;
+      expect(err).to.deep.equal({
+        nested: {
+          office: {
+            email: {
+              required: 'Email field is required.'
+            }
+          }
+        }
+      });
+    });
+
+    it('should success', () => {
+      const result = satpam.validate(rules, {
+        name: 'sendy',
+        nested: {
+          office: {
+            email: 'asd@gg.com'
+          }
+        }
+      });
+      const err = result.messages;
+
+      expect(result.success).to.be.true;
+      expect(err).to.not.have.property('name');
+      expect(err.nested.office).to.not.have.property('email');
+      expect(err.nested.office).to.not.have.property('emailOptional');
+    });
+  });
 });
 

--- a/test/validator-wrapper/validate.spec.js
+++ b/test/validator-wrapper/validate.spec.js
@@ -87,8 +87,6 @@ describe('Validator.validate()', () => {
       expect(err).to.have.property('name');
       expect(err.name['must-be-ironman']).to.equal('Not ironman D:');
       expect(err).to.not.have.property('phone');
-      expect(err.messageArray.length).to.equal(1);
-      expect(err.messageArray[0]).to.equal('Not ironman D:');
     });
   });
 
@@ -106,7 +104,6 @@ describe('Validator.validate()', () => {
 
       expect(result.success).to.equal(false);
       expect(err.salary['range:$1:$2']).to.equal('Salary must between 0 and 30');
-      expect(err.messageArray.length).to.equal(1);
     });
   });
 
@@ -131,7 +128,6 @@ describe('Validator.validate()', () => {
       const err = result.messages;
 
       expect(result.success).to.equal(false);
-      expect(err.messageArray.length).to.equal(4);
       expect(err.name['must-equal:$1']).to.equal('Name must equal sendyhalim !!');
       expect(err.address['must-equal:$1']).to.equal('Address must equal dimana aja bole !!');
       expect(err.address['required']).to.equal('Address field is required.');
@@ -186,7 +182,6 @@ describe('Validator.validate()', () => {
       const err = result.messages;
 
       expect(result.success).to.be.true;
-      expect(err.messageArray).to.be.empty;
     });
 
     it('should success if the second rule of optional rules is satisfied', () => {
@@ -197,7 +192,6 @@ describe('Validator.validate()', () => {
       const err = result.messages;
 
       expect(result.success).to.be.true;
-      expect(err.messageArray).to.be.empty;
     });
 
     it('should success if all the rules are satisfied', () => {
@@ -208,7 +202,48 @@ describe('Validator.validate()', () => {
       const err = result.messages;
 
       expect(result.success).to.be.true;
-      expect(err.messageArray).to.be.empty;
+    });
+  });
+
+  context('when given nested validation rules', () => {
+    const rules = {
+      name: ['required'],
+      office: {
+        email: ['required', 'email'],
+        emailOptional: ['email']
+      }
+    };
+
+    it('should fail', () => {
+      const result = satpam.validate(rules, {
+        name: 'sendy',
+        office: {}
+      });
+      const err = result.messages;
+
+      expect(result.success).to.be.false;
+      expect(err).to.deep.equal({
+        office: {
+          email: {
+            required: 'Email field is required.'
+          }
+        }
+      });
+    });
+
+    it('should success', () => {
+      const result = satpam.validate(rules, {
+        name: 'sendy',
+        office: {
+          email: 'asd@gg.com'
+        }
+      });
+      const err = result.messages;
+
+      expect(result.success).to.be.true;
+      expect(err).to.not.have.property('name');
+      expect(err.office).to.not.have.property('email');
+      expect(err.office).to.not.have.property('emailOptional');
     });
   });
 });

--- a/test/validators/minimum-age.spec.js
+++ b/test/validators/minimum-age.spec.js
@@ -21,7 +21,6 @@ describe ('MinimumAge validator', () => {
     });
 
     it('should not set validation message', () => {
-      expect(result.messages.messageArray).to.be.empty;
       expect(result.messages).to.not.have.property('birthDate');
     });
   });
@@ -41,10 +40,6 @@ describe ('MinimumAge validator', () => {
     });
 
     it('should set validation message', () => {
-      expect(result.messages.messageArray).to.deep.equal([
-        'Minimum age is 21 years old.'
-      ]);
-
       expect(result.messages.birthDate).to.have.property('minimumAge:$1:$2')
         .that.equals('Minimum age is 21 years old.');
     });


### PR DESCRIPTION
- Remove deprecated `messageArray` property from validation result `messages` property
- Add bility to define nested rules

```
var rules = {
  name: ['required'],
  email: ['required', 'email'],
  productOptions: {
    hasCreditCard: ['required', 'boolean']
  }
};
```