### PR TITLE
Use our own cloneDeep to clone Function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,30 @@ class ValidationMessage {
 }
 
 /**
+ * A custom implementation of lodash clone deep.
+ * We're using this because current version of lodash's cloneDeep does not
+ * clone Function. It's fixed in lodash 4.17.* as far as I know, but we'll use this
+ * until we upgrade lodash :beers:
+ *
+ * @author Sendy Halim <sendy@cermati.com>
+ * @param {Object} obj
+ * @returns {Object}
+ */
+const cloneDeep = obj => {
+  const newObj = {};
+
+  _.forEach(obj, (value, key) => {
+    if (_.isObject(value) && !_.isFunction(value)) {
+      newObj[key] = cloneDeep(value);
+    }
+
+    newObj[key] = value;
+  });
+
+  return newObj;
+};
+
+/**
  * Create a new validator. When it's created, it will have a deep cloned global
  * validation rules and global validation messages. Any changes made to the
  * instance's rules or messages will not affect the global validation rules
@@ -125,7 +149,7 @@ class Validator {
   constructor() {
     this.validation = {
       rules: R.clone(validation),
-      messages: R.clone(validationMessages)
+      messages: cloneDeep(validationMessages)
     };
   }
 


### PR DESCRIPTION
Ramda and lodash cloneDeep does not clone Function, it's fixed in the future version of lodash. We'll use this implementation until we upgrade lodash. :beers: 