### PR TITLE
Optimize bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "2.11.0",
+  "version": "2.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1427,7 +1427,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1842,7 +1843,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1898,6 +1900,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -1941,12 +1944,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2000,6 +2005,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2161,7 +2167,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2199,7 +2206,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -2223,6 +2231,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -2284,7 +2293,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-property": {
       "version": "1.0.2",
@@ -2400,6 +2410,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3048,7 +3059,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {
@@ -24,8 +24,8 @@
   "dependencies": {
     "file-type": "~3.8.0",
     "image-type": "^2.0.2",
-    "lodash": "~4.3.0",
-    "moment": "~2.23.0",
+    "lodash": "^4.3.0",
+    "moment": "^2.23.0",
     "noes": "~1.1.1",
     "ramda": "^0.25.0",
     "read-chunk": "^1.0.1",

--- a/src/validators/integer.js
+++ b/src/validators/integer.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isInteger from 'lodash/isInteger';
 import isNil from 'ramda/src/isNil';
 import isEmpty from 'ramda/src/isEmpty';
 
@@ -14,7 +14,7 @@ const validate = val => {
     return false;
   }
 
-  return _.isInteger(numberVal);
+  return isInteger(numberVal);
 };
 
 const message = '<%= propertyName %> must be an integer.';


### PR DESCRIPTION
- Changed an import from `import _ from 'lodash'` to `import isInteger from 'lodash/isInteger'` to prevent all of lodash's functions from being bundled
- Change dependency version requirements from ~ to ^ so there will only be one version of lodash and moment for satpam users who use either lodash or moment with different minor version (for example one of our projects uses lodash 4.17)