### PR TITLE
Fix error in frontend validation which message has inputObj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satpam",
-  "version": "4.11.0",
+  "version": "4.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.11.0",
+      "version": "4.12.1",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -287,7 +287,7 @@ class Validator {
           return {
             success: false,
             ruleName: ruleObj.fullName,
-            message: validator.getValidationMessage(ruleObj, propertyName, val)
+            message: validator.getValidationMessage(ruleObj, inputObj, propertyName, val)
           }
         }
 
@@ -363,17 +363,19 @@ class Validator {
 
   /**
    * @param ruleObj
+   * @param inputObj
    * @param propertyName
    * @param val
    * @returns {String}
    */
-  getValidationMessage(ruleObj, propertyName, val) {
+  getValidationMessage(ruleObj, inputObj, propertyName, val) {
     const message = this.validation.messages[ruleObj.fullName];
     const messageTemplate = is(Function, message) ? message(ruleObj, propertyName, val) : message;
     const compiled = template(messageTemplate);
     propertyName = startCase(propertyName);
 
     return compiled({
+      inputObj: inputObj,
       propertyName: propertyName,
       ruleName: ruleObj.fullName,
       ruleParams: ruleObj.params,


### PR DESCRIPTION
Currently in frontend validation there is error in rules `equal-to-field:$1` and `not-equal-to-field:$1`.
This was caused by message that has `inputObj` but the validation message compilation is not pasing `inputObj`

(Note: This is localized problem in frontend.js)