### PR TITLE
remove mobilePhoneNumber prefix 0814

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satpam",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.12.1",
+      "version": "4.12.2",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/validators/mobile-phone-number.js
+++ b/src/validators/mobile-phone-number.js
@@ -13,7 +13,6 @@ const prefixMap = {
   '0811': true, // KartuHALO Telkomsel
   '0812': true, // SimPATI, KartuHALO Telkomsel
   '0813': true, // SimPATI, KartuHALO Telkomsel
-  '0814': true, // Indosat 3,5G Broadband Indosat (IndosatM2)
   '0815': true, // Mentari lama, Matrix Indosat
   '0816': true, // Mentari, Matrix Indosat
   '0817': true, // XL Prabayar, XL Pascabayar XL Axiata


### PR DESCRIPTION
As we could see from Indosat announcement regarding prefix, IM3 ooreedo with prefix 0814 will be no longer supported. Hence, the prefix should be removed.