### PR TITLE
feat: added internationalPhoneNumber validation rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satpam",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.12.1",
+      "version": "4.13.0",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,11 @@ import array from './validators/array';
 import beginWith from './validators/begin-with';
 import between from './validators/between';
 import boolean from './validators/boolean';
+import containsAlphabet from './validators/contains-alphabet';
+import containsDigit from './validators/contains-digit';
+import containsLowerCase from './validators/contains-lower-case';
+import containsSymbol from './validators/contains-symbol';
+import containsUpperCase from './validators/contains-upper-case';
 import creditCard from './validators/credit-card';
 import date from './validators/date';
 import dateAfter from './validators/date-after';
@@ -26,10 +31,6 @@ import dateTimeAfter from './validators/date-time-after';
 import dateTimeAfterOrEqual from './validators/date-time-after-or-equal';
 import dateTimeBefore from './validators/date-time-before';
 import dateTimeBeforeOrEqual from './validators/date-time-before-or-equal';
-import timeAfter from './validators/time-after';
-import timeAfterOrEqual from './validators/time-after-or-equal';
-import timeBefore from './validators/time-before';
-import timeBeforeOrEqual from './validators/time-before-or-equal';
 import dateFormat from './validators/date-format';
 import email from './validators/email';
 import emptyString from './validators/empty-string';
@@ -37,6 +38,7 @@ import equal from './validators/equal';
 import equalToField from './validators/equal-to-field';
 import fileType from './validators/file-type';
 import fqdn from './validators/fqdn';
+import hostname from './validators/hostname';
 import image from './validators/image';
 import imei from './validators/imei';
 import indonesiaIdCardNumberBirthDate from './validators/indonesia-id-card-number-birth-date';
@@ -45,6 +47,7 @@ import indonesiaIdCardNumberProvince from './validators/indonesia-id-card-number
 import indonesiaIdCardNumberValidProvince from './validators/indonesia-id-card-number-valid-province';
 import indonesianName from './validators/indonesian-name';
 import integer from './validators/integer';
+import internationalPhoneNumber from './validators/international-phone-number';
 import ip from './validators/ip';
 import length from './validators/length';
 import maxLength from './validators/max-length';
@@ -55,6 +58,7 @@ import minValue from './validators/min-value';
 import minimumAge from './validators/minimum-age';
 import mobilePhoneNumber from './validators/mobile-phone-number';
 import mongoId from './validators/mongo-id';
+import multipleOf from './validators/multiple-of';
 import nonBlank from './validators/non-blank';
 import notDisposableEmail from './validators/not-disposable-email';
 import notEqual from './validators/not-equal';
@@ -62,8 +66,9 @@ import notEqualToField from './validators/not-equal-to-field';
 import notEqualEmailDomain from './validators/not-equal-email-domain';
 import notMemberOf from './validators/not-member-of';
 import numeric from './validators/numeric';
-import phoneNumber from './validators/phone-number';
 import pattern from './validators/pattern';
+import phoneNumber from './validators/phone-number';
+import plainObject from './validators/plain-object';
 import regex from './validators/regex';
 import required from './validators/required';
 import requiredIf from './validators/required-if';
@@ -71,17 +76,13 @@ import requiredIfNot from './validators/required-if-not';
 import someMemberOf from './validators/some-member-of';
 import string from './validators/string';
 import taxId from './validators/tax-id';
+import timeAfter from './validators/time-after';
+import timeAfterOrEqual from './validators/time-after-or-equal';
+import timeBefore from './validators/time-before';
+import timeBeforeOrEqual from './validators/time-before-or-equal';
 import url from './validators/url';
-import uuid from './validators/uuid';
-import multipleOf from './validators/multiple-of';
-import containsAlphabet from './validators/contains-alphabet';
-import containsDigit from './validators/contains-digit';
-import containsSymbol from './validators/contains-symbol';
-import containsLowerCase from './validators/contains-lower-case';
-import containsUpperCase from './validators/contains-upper-case';
-import plainObject from './validators/plain-object';
-import hostname from './validators/hostname';
 import urlProtocol from './validators/url-protocol';
+import uuid from './validators/uuid';
 
 let validation = {
   'beginWith:$1': beginWith.validate,
@@ -90,15 +91,11 @@ let validation = {
   'dateAfterOrEqual:$1:$2:$3:$4': dateAfterOrEqual.validate,
   'dateBefore:$1:$2:$3:$4': dateBefore.validate,
   'dateBeforeOrEqual:$1:$2:$3:$4': dateBeforeOrEqual.validate,
+  'dateFormat:$1': dateFormat.validate,
   'dateTimeAfter:$1:$2:$3:$4': dateTimeAfter.validate,
   'dateTimeAfterOrEqual:$1:$2:$3:$4': dateTimeAfterOrEqual.validate,
   'dateTimeBefore:$1:$2:$3:$4': dateTimeBefore.validate,
   'dateTimeBeforeOrEqual:$1:$2:$3:$4': dateTimeBeforeOrEqual.validate,
-  'timeAfter:$1:$2:$3': timeAfter.validate,
-  'timeAfterOrEqual:$1:$2:$3': timeAfterOrEqual.validate,
-  'timeBefore:$1:$2:$3': timeBefore.validate,
-  'timeBeforeOrEqual:$1:$2:$3': timeBeforeOrEqual.validate,
-  'dateFormat:$1': dateFormat.validate,
   'equal:$1': equal.validate,
   'equal-to-field:$1': equalToField.validate,
   'fileType:$1': fileType.validate,
@@ -114,24 +111,30 @@ let validation = {
   'minLength:$1': minLength.validate,
   'minValue:$1': minValue.validate,
   'minimumAge:$1:$2': minimumAge.validate,
+  'multipleOf:$1': multipleOf.validate,
   'not-equal:$1': notEqual.validate,
-  'not-equal-to-field:$1': notEqualToField.validate,
   'not-equal-email-domain:$1': notEqualEmailDomain.validate,
+  'not-equal-to-field:$1': notEqualToField.validate,
   'not-memberOf:$1': notMemberOf.validate,
   'pattern:$1:$2': pattern.validate,
   'requiredIf:$1:$2': requiredIf.validate,
   'requiredIfNot:$1:$2': requiredIfNot.validate,
   'some-memberOf:$1': someMemberOf.validate,
   'taxId:$1': taxId.validate,
-  'multipleOf:$1': multipleOf.validate,
+  'timeAfter:$1:$2:$3': timeAfter.validate,
+  'timeAfterOrEqual:$1:$2:$3': timeAfterOrEqual.validate,
+  'timeBefore:$1:$2:$3': timeBefore.validate,
+  'timeBeforeOrEqual:$1:$2:$3': timeBeforeOrEqual.validate,
+  'urlProtocol:$1': urlProtocol.validate,
+  'uuid:$1': uuid.validate,
   alpha: alpha.validate,
   alphanumeric: alphanumeric.validate,
   array: array.validate,
   boolean: boolean.validate,
   containsAlphabet: containsAlphabet.validate,
   containsDigit: containsDigit.validate,
-  containsSymbol: containsSymbol.validate,
   containsLowerCase: containsLowerCase.validate,
+  containsSymbol: containsSymbol.validate,
   containsUpperCase: containsUpperCase.validate,
   creditCard: creditCard.validate,
   date: date.validate,
@@ -142,20 +145,19 @@ let validation = {
   image: image.validate,
   imei: imei.validate,
   integer: integer.validate,
+  internationalPhoneNumber: internationalPhoneNumber.validate,
   ip: ip.validate,
   mobilePhoneNumber: mobilePhoneNumber.validate,
   mongoId: mongoId.validate,
   nonBlank: nonBlank.validate,
   notDisposableEmail: notDisposableEmail.validate,
   numeric: numeric.validate,
-  plainObject: plainObject.validate,
   phoneNumber: phoneNumber.validate,
+  plainObject: plainObject.validate,
   regex: regex.validate,
   required: required.validate,
   string: string.validate,
   url: url.validate,
-  'urlProtocol:$1': urlProtocol.validate,
-  'uuid:$1': uuid.validate
 };
 
 let validationMessages = {
@@ -217,6 +219,7 @@ let validationMessages = {
   image: image.message,
   imei: imei.message,
   integer: integer.message,
+  internationalPhoneNumber: internationalPhoneNumber.message,
   ip: ip.message,
   mobilePhoneNumber: mobilePhoneNumber.message,
   mongoId: mongoId.message,

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -32,6 +32,7 @@ module.exports = {
   'indonesiaIdCardNumberValidProvince': 'Kode provinsi pada Nomor KTP tidak benar.',
   'indonesianName': 'Nama tidak valid.',
   'integer': 'Input harus berupa angka.',
+  'internationalPhoneNumber': 'Nomor telepon tidak valid.',
   'length:$1': 'Jumlah karakter harus <%= ruleParams[0] %>.',
   'maxLength:$1': 'Jumlah karakter tidak boleh lebih dari <%= ruleParams[0] %>.',
   'maxValue:$1': 'Input tidak boleh lebih dari <%= ruleParams[0] %>.',

--- a/src/validators/international-phone-number.js
+++ b/src/validators/international-phone-number.js
@@ -1,0 +1,285 @@
+// Maximum international mobile phone number length including country code is 15 digits. Source: https://en.wikipedia.org/wiki/E.164
+const internationalPhoneNumberRegExp = /^\+?[0-9]{2,15}$/;
+
+/**
+ * Source: https://www.iban.com/dialing-codes (country code)
+ */
+const oneNumPrefixMap = {
+  '1': true, // American Samoa, Anguilla, Antigua and Barbuda, Bahamas, Barbados, Bermuda, British Virgin Islands, Canada, Cayman Islands, Dominica, Dominican Rep., Grenada, Guam, Jamaica, Montserrat, Northern Marianas, Puerto Rico, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines, Sint Maarten (Dutch part), Trinidad and Tobago, Turks and Caicos Islands, United States, United States Virgin Islands, and some countries' National Prefixes
+  '7': true, // Kazakhstan, Russian Federation
+};
+
+const twoNumPrefixMap = {
+  '20': true, // Egypt
+  '27': true, // South Africa
+  '30': true, // Greece
+  '31': true, // Netherlands
+  '32': true, // Belgium
+  '33': true, // France
+  '34': true, // Spain
+  '36': true, // Hungary
+  '39': true, // Italy, Vatican
+  '40': true, // Romania
+  '41': true, // Switzerland
+  '43': true, // Austria
+  '44': true, // United Kingdom
+  '45': true, // Denmark
+  '46': true, // Sweden
+  '47': true, // Norway
+  '48': true, // Poland
+  '49': true, // Germany
+  '51': true, // Peru
+  '52': true, // Mexico
+  '53': true, // Cuba
+  '54': true, // Argentina
+  '55': true, // Brazil
+  '56': true, // Chile
+  '57': true, // Colombia
+  '58': true, // Venezuela (Bolivarian Republic of)
+  '60': true, // Malaysia
+  '61': true, // Australia
+  '62': true, // Indonesia
+  '63': true, // Philippines
+  '64': true, // New Zealand
+  '65': true, // Singapore
+  '66': true, // Thailand
+  '81': true, // Japan
+  '82': true, // Korea (Rep. of)
+  '84': true, // Viet Nam
+  '86': true, // China
+  '90': true, // Turkey
+  '91': true, // India
+  '92': true, // Pakistan
+  '93': true, // Afghanistan
+  '94': true, // Sri Lanka
+  '95': true, // Myanmar
+  '98': true, // Iran (Islamic Republic of)
+};
+
+const threeNumPrefixMap = {
+  '211': true, // South Sudan
+  '212': true, // Morocco
+  '213': true, // Algeria
+  '216': true, // Tunisia
+  '218': true, // Libya
+  '220': true, // Gambia
+  '221': true, // Senegal
+  '222': true, // Mauritania
+  '223': true, // Mali
+  '224': true, // Guinea
+  '225': true, // Côte d'Ivoire
+  '226': true, // Burkina Faso
+  '227': true, // Niger
+  '228': true, // Togo
+  '229': true, // Benin
+  '230': true, // Mauritius
+  '231': true, // Liberia
+  '232': true, // Sierra Leone
+  '233': true, // Ghana
+  '234': true, // Nigeria
+  '235': true, // Chad
+  '236': true, // Central African Rep.
+  '237': true, // Cameroon
+  '238': true, // Cape Verde
+  '239': true, // Sao Tome and Principe
+  '240': true, // Equatorial Guinea
+  '241': true, // Gabon
+  '242': true, // Congo
+  '243': true, // Dem. Rep. of the Congo
+  '244': true, // Angola
+  '245': true, // Guinea-Bissau
+  '246': true, // Diego Garcia
+  '247': true, // Saint Helena, Ascension and Tristan da Cunha
+  '248': true, // Seychelles
+  '249': true, // Sudan
+  '250': true, // Rwanda
+  '251': true, // Ethiopia
+  '252': true, // Somalia
+  '253': true, // Djibouti
+  '254': true, // Kenya
+  '255': true, // Tanzania
+  '256': true, // Uganda
+  '257': true, // Burundi
+  '258': true, // Mozambique
+  '260': true, // Zambia
+  '261': true, // Madagascar
+  '262': true, // French Dep. and Territories in the Indian Ocean
+  '263': true, // Zimbabwe
+  '264': true, // Namibia
+  '265': true, // Malawi
+  '266': true, // Lesotho
+  '267': true, // Botswana
+  '268': true, // Swaziland
+  '269': true, // Comoros
+  '290': true, // Saint Helena, Ascension and Tristan da Cunha
+  '291': true, // Eritrea
+  '297': true, // Aruba
+  '298': true, // Faroe Islands
+  '299': true, // Greenland
+  '350': true, // Gibraltar
+  '351': true, // Portugal
+  '352': true, // Luxembourg
+  '353': true, // Ireland
+  '354': true, // Iceland
+  '355': true, // Albania
+  '356': true, // Malta
+  '357': true, // Cyprus
+  '358': true, // Finland
+  '359': true, // Bulgaria
+  '370': true, // Lithuania
+  '371': true, // Latvia
+  '372': true, // Estonia
+  '373': true, // Moldova (Republic of)
+  '374': true, // Armenia
+  '375': true, // Belarus
+  '376': true, // Andorra
+  '377': true, // Monaco
+  '378': true, // San Marino
+  '379': true, // Vatican
+  '380': true, // Ukraine
+  '381': true, // Serbia
+  '382': true, // Montenegro
+  '385': true, // Croatia
+  '386': true, // Slovenia
+  '387': true, // Bosnia and Herzegovina
+  '388': true, // Group of countries, shared code
+  '389': true, // The Former Yugoslav Republic of Macedonia
+  '420': true, // Czech Rep.
+  '421': true, // Slovakia
+  '423': true, // Liechtenstein
+  '500': true, // Falkland Islands (Malvinas)
+  '501': true, // Belize
+  '502': true, // Guatemala
+  '503': true, // El Salvador
+  '504': true, // Honduras
+  '505': true, // Nicaragua
+  '506': true, // Costa Rica
+  '507': true, // Panama
+  '508': true, // Saint Pierre and Miquelon
+  '509': true, // Haiti
+  '590': true, // Guadeloupe
+  '591': true, // Bolivia (Plurinational State of)
+  '592': true, // Guyana
+  '593': true, // Ecuador
+  '594': true, // French Guiana
+  '595': true, // Paraguay
+  '596': true, // Martinique
+  '597': true, // Suriname
+  '598': true, // Uruguay
+  '599': true, // Bonaire, Sint Eustatius and Saba, Curaçao
+  '670': true, // Timor-Leste
+  '672': true, // Australian External Territories
+  '673': true, // Brunei Darussalam
+  '674': true, // Nauru
+  '675': true, // Papua New Guinea
+  '676': true, // Tonga
+  '677': true, // Solomon Islands
+  '678': true, // Vanuatu
+  '679': true, // Fiji
+  '680': true, // Palau
+  '681': true, // Wallis and Futuna
+  '682': true, // Cook Islands
+  '683': true, // Niue
+  '685': true, // Samoa
+  '686': true, // Kiribati
+  '687': true, // New Caledonia
+  '688': true, // Tuvalu
+  '689': true, // French Polynesia
+  '690': true, // Tokelau
+  '691': true, // Micronesia
+  '692': true, // Marshall Islands
+  '800': true, // International Freephone Service
+  '808': true, // International Shared Cost Service (ISCS)
+  '850': true, // Dem. People's Rep. of Korea
+  '852': true, // Hong Kong, China
+  '853': true, // Macao, China
+  '855': true, // Cambodia
+  '856': true, // Lao P.D.R.
+  '870': true, // Inmarsat SNAC
+  '878': true, // Universal Personal Telecommunication (UPT)
+  '880': true, // Bangladesh
+  '881': true, // Global Mobile Satellite System (GMSS), shared
+  '882': true, // International Networks, shared code
+  '883': true, // International Networks, shared code
+  '886': true, // Taiwan, China
+  '888': true, // Telecommunications for Disaster Relief (TDR)
+  '960': true, // Maldives
+  '961': true, // Lebanon
+  '962': true, // Jordan
+  '963': true, // Syrian Arab Republic
+  '964': true, // Iraq
+  '965': true, // Kuwait
+  '966': true, // Saudi Arabia
+  '967': true, // Yemen
+  '968': true, // Oman
+  '970': true, // Reserved
+  '971': true, // United Arab Emirates
+  '972': true, // Israel
+  '973': true, // Bahrain
+  '974': true, // Qatar
+  '975': true, // Bhutan
+  '976': true, // Mongolia
+  '977': true, // Nepal
+  '979': true, // International Premium Rate Service (IPRS)
+  '991': true, // Trial of a proposed new international service
+  '992': true, // Tajikistan
+  '993': true, // Turkmenistan
+  '994': true, // Azerbaijan
+  '995': true, // Georgia
+  '996': true, // Kyrgyzstan
+  '998': true, // Uzbekistan
+};
+
+
+/**
+ * Validates whether the given string is a valid international phone number.
+ * This rule only checks whether the given string prefix is a valid country code (or national prefix).
+ * Unlike the mobilePhoneNumber rule, this rule does not check if a telephone service operator
+ * with the given phone number prefix actually exists or not.
+ * @param {string} [val]
+ * @returns {boolean}
+ */
+const validate = val => {
+  if (!val) {
+    return true;
+  }
+
+  // If does not pass the regex, return false
+  const passInternationalPhoneNumberRegExp = internationalPhoneNumberRegExp.test(val);
+
+  if (!passInternationalPhoneNumberRegExp) {
+    return false;
+  }
+
+  // If pass, continue to validate the prefix
+  // Strip the plus sign prefix
+  const valWithoutPlusPrefix = val.replace(/^\+/, '');
+
+  // Match the first n numbers to be in the list
+  const oneNumPrefix = valWithoutPlusPrefix.slice(0, 1);
+  const existsInOnePrefixList = oneNumPrefixMap[oneNumPrefix];
+
+  if (existsInOnePrefixList) {
+    return true;
+  }
+
+  const twoNumPrefix = valWithoutPlusPrefix.slice(0, 2);
+  const existsInTwoPrefixList = twoNumPrefixMap[twoNumPrefix];
+
+  if (existsInTwoPrefixList) {
+    return true;
+  }
+
+  const threeNumPrefix = valWithoutPlusPrefix.slice(0, 3);
+  const existsInThreePrefixList = threeNumPrefixMap[threeNumPrefix];
+
+  if (existsInThreePrefixList) {
+    return true;
+  }
+
+  return false;
+};
+
+const message = '<%= propertyName %> field is not a valid international phone number.';
+
+export default {validate, message};

--- a/test/validators/international-phone-number.spec.js
+++ b/test/validators/international-phone-number.spec.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('international phone number validator', () => {
+  const rule = {
+    phone: ['internationalPhoneNumber']
+  };
+
+  context('with empty international phone number', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: '' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with international phone number starts with 60', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: '60112345678' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with international phone number starts with +65', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: '+658123456' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with international phone number starts with 680', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: '68012345678' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with valid indonesia national phone number starts with 08', () => {
+    it('should fail', () => {
+      const result = validator.validate(rule, { phone: '08123456789' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('phone');
+    });
+  });
+
+  context('with valid indonesia international phone number starts with +62', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: '+628123456789' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with invalid international phone number starts with 990', () => {
+    it('should fail', () => {
+      const result = validator.validate(rule, { phone: '990658123456' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('phone');
+    });
+  });
+
+  context('with invalid international phone number starts with +671', () => {
+    it('should fail', () => {
+      const result = validator.validate(rule, { phone: '+671658123456' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('phone');
+    });
+  });
+});


### PR DESCRIPTION
The rule succeeds if the given string is a valid international phone number. It fails if the given string is a national phone number (i.e. 08123456789 will fail, but +628123456789 will pass), or not a phone number at all. It doesn't check whether there is a telephone service provider with the given phone number prefix or not (unlike `mobilePhoneNumber` rule which checks whether there is a mobile phone number service provider with the given prefix).