### PR TITLE
fix: internationalPhoneNumber throws error when validating number value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/validators/international-phone-number.js
+++ b/src/validators/international-phone-number.js
@@ -236,7 +236,7 @@ const threeNumPrefixMap = {
  * This rule only checks whether the given string prefix is a valid country code (or national prefix).
  * Unlike the mobilePhoneNumber rule, this rule does not check if a telephone service operator
  * with the given phone number prefix actually exists or not.
- * @param {string} [val]
+ * @param {string|number} [val]
  * @returns {boolean}
  */
 const validate = val => {
@@ -244,8 +244,10 @@ const validate = val => {
     return true;
   }
 
+  const valStr = String(val);
+
   // If does not pass the regex, return false
-  const passInternationalPhoneNumberRegExp = internationalPhoneNumberRegExp.test(val);
+  const passInternationalPhoneNumberRegExp = internationalPhoneNumberRegExp.test(valStr);
 
   if (!passInternationalPhoneNumberRegExp) {
     return false;
@@ -253,7 +255,7 @@ const validate = val => {
 
   // If pass, continue to validate the prefix
   // Strip the plus sign prefix
-  const valWithoutPlusPrefix = val.replace(/^\+/, '');
+  const valWithoutPlusPrefix = valStr.replace(/^\+/, '');
 
   // Match the first n numbers to be in the list
   const oneNumPrefix = valWithoutPlusPrefix.slice(0, 1);

--- a/test/validators/international-phone-number.spec.js
+++ b/test/validators/international-phone-number.spec.js
@@ -16,7 +16,7 @@ describe('international phone number validator', () => {
     });
   });
 
-  context('with international phone number starts with 60', () => {
+  context('with valid international phone number starts with 60', () => {
     it('should success', () => {
       const result = validator.validate(rule, { phone: '60112345678' });
       const err = result.messages;
@@ -26,7 +26,7 @@ describe('international phone number validator', () => {
     });
   });
 
-  context('with international phone number starts with +65', () => {
+  context('with valid international phone number starts with +65', () => {
     it('should success', () => {
       const result = validator.validate(rule, { phone: '+658123456' });
       const err = result.messages;
@@ -36,7 +36,7 @@ describe('international phone number validator', () => {
     });
   });
 
-  context('with international phone number starts with 680', () => {
+  context('with valid international phone number starts with 680', () => {
     it('should success', () => {
       const result = validator.validate(rule, { phone: '68012345678' });
       const err = result.messages;
@@ -79,6 +79,26 @@ describe('international phone number validator', () => {
   context('with invalid international phone number starts with +671', () => {
     it('should fail', () => {
       const result = validator.validate(rule, { phone: '+671658123456' });
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('phone');
+    });
+  });
+
+  context('with valid international phone number with type number starts with 60', () => {
+    it('should success', () => {
+      const result = validator.validate(rule, { phone: 60112345678 });
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('phone');
+    });
+  });
+
+  context('with invalid international phone number with type number starts with 990', () => {
+    it('should fail', () => {
+      const result = validator.validate(rule, { phone: 990658123456 });
       const err = result.messages;
 
       expect(result.success).to.equal(false);


### PR DESCRIPTION
add support for `internationalPhoneNumber` rule to accept value of `number` type. Previously, it encountered error `val.replace is not a function`.