### PR TITLE
chore(satpam): add string checker on email validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.13.1",
+  "version": "4.13.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -1,3 +1,5 @@
+import isString from 'lodash/isString';
+
 /**
  * Validate email
  * This is a modified version of github.com/chriso/validator.js `isEmail`
@@ -12,6 +14,10 @@ import fqdn from './fqdn';
 const validate = val => {
   if (!val) {
     return true;
+  }
+
+  if (!isString(val)) {
+    return false;
   }
 
   if (/\s/.test(val)) {

--- a/src/validators/email.js
+++ b/src/validators/email.js
@@ -1,3 +1,5 @@
+import isEmpty from 'lodash/isEmpty';
+import isNil from 'lodash/isNil';
 import isString from 'lodash/isString';
 
 /**
@@ -12,15 +14,9 @@ const emailUserUtf8Regex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\
 import fqdn from './fqdn';
 
 const validate = val => {
-  if (!val) {
+  if (isNil(val) || (isString(val) && isEmpty(val))) {
     return true;
-  }
-
-  if (!isString(val)) {
-    return false;
-  }
-
-  if (/\s/.test(val)) {
+  } else if (!isString(val) || /\s/.test(val)) {
     return false;
   }
 

--- a/test/validators/email.spec.js
+++ b/test/validators/email.spec.js
@@ -45,6 +45,58 @@ describe('email validator', () => {
     });
   });
 
+  context('given invalid value (number)', () => {
+    const input = {
+      email: 123
+    };
+    const result = validator.validate(rules, input);
+    const err = result.messages;
+
+    it('should fail', () => {
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('email');
+    });
+  });
+
+  context('given invalid value (boolean)', () => {
+    const input = {
+      email: true
+    };
+    const result = validator.validate(rules, input);
+    const err = result.messages;
+
+    it('should fail', () => {
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('email');
+    });
+  });
+
+  context('given invalid value (object)', () => {
+    const input = {
+      email: {}
+    };
+    const result = validator.validate(rules, input);
+    const err = result.messages;
+
+    it('should fail', () => {
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('email');
+    });
+  });
+
+  context('given invalid value (array)', () => {
+    const input = {
+      email: []
+    };
+    const result = validator.validate(rules, input);
+    const err = result.messages;
+
+    it('should fail', () => {
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('email');
+    });
+  });
+
   context('given invalid value (garbage)', () => {
     const input = {
       email: '#@%^%#$@#$@#.com'


### PR DESCRIPTION
currently, if we try to validate `email` and the input is not string, we will face error `Uncaught TypeError: val.split is not a function`.
We should check whether the `val` is string or not