### PR TITLE
[T100902] feat(lodash): Don't import whole lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.14.1",
+  "version": "4.15.1",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils/lodash-wrapper.js
+++ b/src/utils/lodash-wrapper.js
@@ -1,0 +1,28 @@
+// Use this lodash wrapper if you need to chain methods.
+// Ensure the methods you need is included in the mixin.
+
+import chain from 'lodash/chain';
+import compact from 'lodash/compact';
+import first from 'lodash/first';
+import get from 'lodash/get';
+import map from 'lodash/map';
+import mixin from 'lodash/mixin';
+import split from 'lodash/split';
+import toLower from 'lodash/toLower';
+import value from 'lodash/value';
+import wrapperLodash from 'lodash/wrapperLodash';
+
+const _ = mixin(wrapperLodash, {
+  chain,
+  compact,
+  first,
+  get,
+  map,
+  split,
+  toLower,
+});
+
+// .value() cannot be inserted inside mixin
+_.prototype.value = value;
+
+export default _;

--- a/src/validators/not-equal-email-domain.js
+++ b/src/validators/not-equal-email-domain.js
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import trim from 'lodash/trim';
+import includes from 'lodash/includes';
+
+import _ from '../utils/lodash-wrapper';
 
 const fullName = 'not-equal-email-domain:$1';
 
@@ -35,11 +38,11 @@ const validate = (val, ruleObj) => {
   const prohibitedDomains = _.chain(ruleObj.params[0])
     .toLower()
     .split(',')
-    .map(domain => _.trim(domain))
+    .map(domain => trim(domain))
     .compact()
     .value();
 
-  return !_.includes(prohibitedDomains, lowerDomain);
+  return !includes(prohibitedDomains, lowerDomain);
 };
 
 const message = '<%= propertyName %>\'s domain is not valid.';

--- a/src/validators/some-member-of.js
+++ b/src/validators/some-member-of.js
@@ -1,17 +1,20 @@
-import _ from 'lodash';
+import includes from 'lodash/includes';
+import isArray from 'lodash/isArray';
+import isUndefined from 'lodash/isUndefined';
+import some from 'lodash/some';
 
 const fullName = 'some-memberOf:$1';
 
 const validate = (val, ruleObj) => {
-  if (_.isUndefined(val)) {
+  if (isUndefined(val)) {
     return false;
   }
 
-  const valArray = _.isArray(val) ? val : [val];
+  const valArray = isArray(val) ? val : [val];
   const list = ruleObj.params[0];
-  const inList = item => _.includes(list, item);
+  const inList = item => includes(list, item);
 
-  return _.some(valArray, inList);
+  return some(valArray, inList);
 };
 
 const message = '<%= propertyName %> must be one of <%= ruleParams[0] %>.';

--- a/src/validators/time-after-or-equal.js
+++ b/src/validators/time-after-or-equal.js
@@ -1,6 +1,6 @@
 import always from 'ramda/src/always';
 import moment from 'moment';
-import _ from 'lodash';
+import join from 'lodash/join';
 
 const fullName = 'timeAfterOrEqual:$1:$2:$3';
 
@@ -48,7 +48,7 @@ const validate = (val, ruleObj) => {
   }
 
   messages.push('.');
-  message.toString = always(_.join(messages, ''));
+  message.toString = always(join(messages, ''));
 
   return timeInput.isSameOrAfter(time);
 };

--- a/src/validators/time-after.js
+++ b/src/validators/time-after.js
@@ -1,7 +1,6 @@
 import always from 'ramda/src/always';
 import moment from 'moment';
-
-import _ from 'lodash';
+import join from 'lodash/join';
 
 const fullName = 'timeAfter:$1:$2:$3';
 
@@ -49,7 +48,7 @@ const validate = (val, ruleObj) => {
   }
 
   messages.push('.');
-  message.toString = always(_.join(messages, ''));
+  message.toString = always(join(messages, ''));
 
   return timeInput.isAfter(time);
 };

--- a/src/validators/time-before-or-equal.js
+++ b/src/validators/time-before-or-equal.js
@@ -1,6 +1,6 @@
 import always from 'ramda/src/always';
 import moment from 'moment';
-import _ from 'lodash';
+import join from 'lodash/join';
 
 const fullName = 'timeBeforeOrEqual:$1:$2:$3';
 
@@ -48,7 +48,7 @@ const validate = (val, ruleObj) => {
   }
 
   messages.push('.');
-  message.toString = always(_.join(messages, ''));
+  message.toString = always(join(messages, ''));
 
   return timeInput.isSameOrBefore(time);
 };

--- a/src/validators/time-before.js
+++ b/src/validators/time-before.js
@@ -1,7 +1,6 @@
 import always from 'ramda/src/always';
 import moment from 'moment';
-
-import _ from 'lodash';
+import join from 'lodash/join';
 
 const fullName = 'timeBefore:$1:$2:$3';
 
@@ -49,7 +48,7 @@ const validate = (val, ruleObj) => {
   }
 
   messages.push('.');
-  message.toString = always(_.join(messages, ''));
+  message.toString = always(join(messages, ''));
 
   return timeInput.isBefore(time);
 };

--- a/src/validators/url-protocol.js
+++ b/src/validators/url-protocol.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from '../utils/lodash-wrapper';
 
 const fullName = 'urlProtocol:$1';
 

--- a/test/validator-wrapper/validate.spec.js
+++ b/test/validator-wrapper/validate.spec.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
-import _ from 'lodash';
+import assign from 'lodash/assign';
+import identity from 'lodash/identity';
+import toLower from 'lodash/toLower';
 import satpam from '../../lib';
 
 describe('Validator.validate()', () => {
@@ -360,7 +362,7 @@ describe('Validator.validate()', () => {
       it('should return formatted validation message', () => {
         const options = {
           validationMessageParamsFormatter: ({ propertyName, propertyValue, inputObj, violatedRule }) => {
-            const ruleParamsFormatter = validationMessageParamsFormatterByRuleFullName[violatedRule.fullName] || _.identity;
+            const ruleParamsFormatter = validationMessageParamsFormatterByRuleFullName[violatedRule.fullName] || identity;
 
             return {
               ruleParams: ruleParamsFormatter(violatedRule.params)
@@ -388,7 +390,7 @@ describe('Validator.validate()', () => {
       it('should return formatted validation message', () => {
         const options = {
           validationMessageParamsFormatter: ({ propertyName, propertyValue, inputObj, violatedRule }) => {
-            const ruleParamsFormatter = validationMessageParamsFormatterByRuleFullName[violatedRule.fullName] || _.identity;
+            const ruleParamsFormatter = validationMessageParamsFormatterByRuleFullName[violatedRule.fullName] || identity;
 
             return {
               propertyName: 'Pendapatan',
@@ -417,7 +419,7 @@ describe('Validator.validate()', () => {
 
     const validationMessagePackProvider = ({ propertyName, inputObj, violatedRule }) => {
       if (propertyName === 'name') {
-        return _.assign({}, messagePack, {
+        return assign({}, messagePack, {
           'required': 'Customized required rule for name, *evil laughs'
         });
       }
@@ -436,7 +438,7 @@ describe('Validator.validate()', () => {
       }
 
       return {
-        propertyName: _.toLower(propertyName),
+        propertyName: toLower(propertyName),
         ruleParams
       };
     }


### PR DESCRIPTION
Previously, lodash are imported as a whole on some modules. This is not an issue for backend integration, but it ended up  including the whole lodash package on our front end client bundle despite not using all of the methods. Testing on one of our page locally shows that we can potentialy reduce ~25 kB of the client bundle if we don't import lodash package as a whole.

Changes made on this PR:
- Only import lodash methods which are needed for each modules
```
// before
import _ from 'lodash'

const a = _.get(b, 'c');

// after
import get from 'lodash/get';

const a = get(b, 'c');
```
- Lodash `_.chain` needs to be customized because by default it includes all of the lodash method available. We create a custom one in `src/utils/lodash-wrapper.js` which only includes the methods needed for `_.chain` method.
```
// before
import _ from 'lodash'

const a = _.chain(b)
  .get('c')
  .negate()
  .value();

// after
import _ from '../utils/lodash-wrapper';

const a = _.chain(b)
  .get('c')
  .negate()
  .value();
```