### PR TITLE
[T99687] BREAKING CHANGE(dayjs): Migrate moment to dayjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.0.0] - 2024-05-07
+
+### Changed features
+
+- BREAKING: Migrate date utilities from previously using moment to now using dayjs to optimize bundle size
+  - Previously, parsing an incomplete input date using moment will fill the missing value. dayjs doesn't have this behavior. Considering adding `date-format` validation if your input is not guaranteed to have a valid format.
+    ```js
+    const dateWithoutSeconds = '2024-05-07T13:00';
+    const dateFormatExpectingSeconds = 'YYYY-MM-DDTHH:mm:ss';
+
+    moment(dateWithoutSeconds, dateFormatExpectingSeconds).format()
+    > '2024-05-07T13:00:00+07:00'
+
+    dayjs(dateWithoutSeconds, dateFormatExpectingSeconds).format()
+    > 'Invalid Date'
+    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed features
 
 - BREAKING: Migrate date utilities from previously using moment to now using dayjs to optimize bundle size
-  - Previously, parsing an incomplete input date using moment will fill the missing value. dayjs doesn't have this behavior. Considering adding `date-format` validation if your input is not guaranteed to have a valid format.
+  - Previously, parsing an incomplete input date using moment will fill the missing value. dayjs doesn't have this behavior when extending custom parse format (which we do extend). Considering adding `date-format` validation if your input is not guaranteed to have a valid format.
     ```js
     const dateWithoutSeconds = '2024-05-07T13:00';
     const dateFormatExpectingSeconds = 'YYYY-MM-DDTHH:mm:ss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "satpam",
-  "version": "4.13.0",
+  "version": "4.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.13.0",
+      "version": "4.15.1",
       "license": "MIT",
       "dependencies": {
+        "dayjs": "~1.11.10",
         "file-type": "~3.8.0",
         "image-type": "~4.1.0",
         "lodash": "~4.17.21",
-        "moment": "~2.29.4",
         "noes": "~1.1.1",
         "ramda": "~0.25.0",
         "read-chunk": "~1.0.1"
@@ -2926,6 +2926,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4847,14 +4852,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -8618,6 +8615,11 @@
         "which": "^2.0.1"
       }
     },
+    "dayjs": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10086,11 +10088,6 @@
           }
         }
       }
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.15.1",
+  "version": "5.0.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/cermati/satpam",
   "dependencies": {
+    "dayjs": "~1.11.10",
     "file-type": "~3.8.0",
     "image-type": "~4.1.0",
     "lodash": "~4.17.21",
-    "moment": "~2.29.4",
     "noes": "~1.1.1",
     "ramda": "~0.25.0",
     "read-chunk": "~1.0.1"

--- a/src/validators/date-after-or-equal.js
+++ b/src/validators/date-after-or-equal.js
@@ -1,5 +1,10 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateAfterOrEqual:$1:$2:$3:$4';
 
@@ -18,14 +23,14 @@ const validate = (val, ruleObj) => {
 
   let date;
   const dateInputFormat = ruleObj.params[0];
-  const dateInput = moment(val, dateInputFormat);
+  const dateInput = dayjs(val, dateInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'days';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    date = moment();
+    date = dayjs();
   } else {
-    date = moment(ruleObj.params[1], dateInputFormat);
+    date = dayjs(ruleObj.params[1], dateInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-after.js
+++ b/src/validators/date-after.js
@@ -1,5 +1,8 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateAfter:$1:$2:$3:$4';
 
@@ -18,14 +21,14 @@ const validate = (val, ruleObj) => {
 
   let date;
   const dateInputFormat = ruleObj.params[0];
-  const dateInput = moment(val, dateInputFormat);
+  const dateInput = dayjs(val, dateInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'days';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    date = moment();
+    date = dayjs();
   } else {
-    date = moment(ruleObj.params[1], dateInputFormat);
+    date = dayjs(ruleObj.params[1], dateInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-before-or-equal.js
+++ b/src/validators/date-before-or-equal.js
@@ -1,5 +1,8 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateBeforeOrEqual:$1:$2:$3:$4';
 
@@ -18,14 +21,14 @@ const validate = (val, ruleObj) => {
 
   let date;
   const dateInputFormat = ruleObj.params[0];
-  const dateInput = moment(val, dateInputFormat);
+  const dateInput = dayjs(val, dateInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'days';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    date = moment();
+    date = dayjs();
   } else {
-    date = moment(ruleObj.params[1], dateInputFormat);
+    date = dayjs(ruleObj.params[1], dateInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-before.js
+++ b/src/validators/date-before.js
@@ -1,5 +1,8 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateBefore:$1:$2:$3:$4';
 
@@ -18,14 +21,14 @@ const validate = (val, ruleObj) => {
 
   let date;
   const dateInputFormat = ruleObj.params[0];
-  const dateInput = moment(val, dateInputFormat);
+  const dateInput = dayjs(val, dateInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'days';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    date = moment();
+    date = dayjs();
   } else {
-    date = moment(ruleObj.params[1], dateInputFormat);
+    date = dayjs(ruleObj.params[1], dateInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-format.js
+++ b/src/validators/date-format.js
@@ -1,4 +1,7 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateFormat:$1';
 
@@ -7,7 +10,7 @@ const validate = (val, ruleObj) => {
     return true;
   }
 
-  return moment(val, ruleObj.params[0], true).isValid();
+  return dayjs(val, ruleObj.params[0], true).isValid();
 };
 
 const message = '<%= propertyName %> must be in format <%= ruleParams[0] %>.';

--- a/src/validators/date-time-after-or-equal.js
+++ b/src/validators/date-time-after-or-equal.js
@@ -1,5 +1,11 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(customParseFormat);
+
 
 const fullName = 'dateTimeAfterOrEqual:$1:$2:$3:$4';
 
@@ -18,14 +24,14 @@ const validate = (val, ruleObj) => {
 
   let dateTime;
   const dateTimeInputFormat = ruleObj.params[0];
-  const dateTimeInput = moment(val, dateTimeInputFormat);
+  const dateTimeInput = dayjs(val, dateTimeInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'seconds';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    dateTime = moment();
+    dateTime = dayjs();
   } else {
-    dateTime = moment(ruleObj.params[1], dateTimeInputFormat);
+    dateTime = dayjs(ruleObj.params[1], dateTimeInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-time-after.js
+++ b/src/validators/date-time-after.js
@@ -1,5 +1,8 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateTimeAfter:$1:$2:$3:$4';
 
@@ -18,14 +21,14 @@ const validate = (val, ruleObj) => {
 
   let dateTime;
   const dateTimeInputFormat = ruleObj.params[0];
-  const dateTimeInput = moment(val, dateTimeInputFormat);
+  const dateTimeInput = dayjs(val, dateTimeInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'seconds';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    dateTime = moment();
+    dateTime = dayjs();
   } else {
-    dateTime = moment(ruleObj.params[1], dateTimeInputFormat);
+    dateTime = dayjs(ruleObj.params[1], dateTimeInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-time-before-or-equal.js
+++ b/src/validators/date-time-before-or-equal.js
@@ -1,5 +1,11 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(isSameOrBefore);
+dayjs.extend(customParseFormat);
+
 
 const fullName = 'dateTimeBeforeOrEqual:$1:$2:$3:$4';
 
@@ -18,14 +24,14 @@ const validate = (val, ruleObj) => {
 
   let dateTime;
   const dateTimeInputFormat = ruleObj.params[0];
-  const dateTimeInput = moment(val, dateTimeInputFormat);
+  const dateTimeInput = dayjs(val, dateTimeInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'seconds';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    dateTime = moment();
+    dateTime = dayjs();
   } else {
-    dateTime = moment(ruleObj.params[1], dateTimeInputFormat);
+    dateTime = dayjs(ruleObj.params[1], dateTimeInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date-time-before.js
+++ b/src/validators/date-time-before.js
@@ -1,5 +1,8 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'dateTimeBefore:$1:$2:$3:$4';
 
@@ -18,14 +21,14 @@ const validate = (val, ruleObj) => {
 
   let dateTime;
   const dateTimeInputFormat = ruleObj.params[0];
-  const dateTimeInput = moment(val, dateTimeInputFormat);
+  const dateTimeInput = dayjs(val, dateTimeInputFormat);
   let offset = Number(ruleObj.params[2]);
   const unit = ruleObj.params[3] || 'seconds';
 
   if (ruleObj.params[1].toLowerCase() === NOW) {
-    dateTime = moment();
+    dateTime = dayjs();
   } else {
-    dateTime = moment(ruleObj.params[1], dateTimeInputFormat);
+    dateTime = dayjs(ruleObj.params[1], dateTimeInputFormat);
   }
 
   // Always start with a defaultMessage

--- a/src/validators/date.js
+++ b/src/validators/date.js
@@ -1,10 +1,10 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 
 const fullName = 'date';
 
 const validate = val => {
   if (val) {
-    return moment(val).isValid();
+    return dayjs(val).isValid();
   }
 
   return true;

--- a/src/validators/indonesia-id-card-number-birth-date.js
+++ b/src/validators/indonesia-id-card-number-birth-date.js
@@ -1,4 +1,7 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'indonesiaIdCardNumberBirthDate:$1:$2';
 
@@ -27,7 +30,7 @@ const validate = (value, ruleObj, propertyName, inputObj)  => {
   const monthAndYearFromIdCard = String(value).substr(8, 4);
   const birthDateInputKey = ruleObj.params[0];
   const birthDateInputFormat = ruleObj.params[1];
-  const birthDateValue = moment(inputObj[birthDateInputKey], birthDateInputFormat).format('DDMMYY');
+  const birthDateValue = dayjs(inputObj[birthDateInputKey], birthDateInputFormat).format('DDMMYY');
 
   return birthDateValue === `${birthDateFromIdCard}${monthAndYearFromIdCard}`;
 };

--- a/src/validators/minimum-age.js
+++ b/src/validators/minimum-age.js
@@ -1,7 +1,10 @@
 import is from 'ramda/src/is';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import { InvalidValidationRuleParameter } from '../data-structures/errors';
+
+dayjs.extend(customParseFormat);
 
 const fullName = 'minimumAge:$1:$2';
 
@@ -28,8 +31,8 @@ const validate = (dateString, ruleObj) => {
   }
 
   const dateInputFormat = ruleObj.params[1];
-  const today = moment();
-  const birthDate = moment(dateString, dateInputFormat);
+  const today = dayjs();
+  const birthDate = dayjs(dateString, dateInputFormat);
   const age = today.diff(birthDate, 'years');
 
   return age > (minimumAge - 1);

--- a/src/validators/time-after-or-equal.js
+++ b/src/validators/time-after-or-equal.js
@@ -1,6 +1,12 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
 import join from 'lodash/join';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import 'dayjs/locale/id';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(utc);
 
 const fullName = 'timeAfterOrEqual:$1:$2:$3';
 
@@ -18,20 +24,20 @@ const validate = (val, ruleObj) => {
 
   messages = ['<%= propertyName %> must be greater than or equal to']
 
-  const timeInput = moment(val);
+  const timeInput = dayjs(val);
   let offset = Number(ruleObj.params[1]);
   const unit = ruleObj.params[2];
 
   let time;
 
   if (ruleObj.params[0].toUpperCase() === NOW) {
-    time = moment();
+    time = dayjs();
 
     messages.push(' now');
   } else {
-    time = moment.unix(ruleObj.params[0]);
+    time = dayjs.unix(ruleObj.params[0]);
 
-    messages.push(` ${moment.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
+    messages.push(` ${dayjs.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
   }
 
   if (offset) {

--- a/src/validators/time-after.js
+++ b/src/validators/time-after.js
@@ -1,6 +1,9 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import join from 'lodash/join';
+
+dayjs.extend(utc);
 
 const fullName = 'timeAfter:$1:$2:$3';
 
@@ -18,20 +21,20 @@ const validate = (val, ruleObj) => {
 
   messages = ['<%= propertyName %> must be greater than'];
 
-  const timeInput = moment(val);
+  const timeInput = dayjs(val);
   let offset = Number(ruleObj.params[1]);
   const unit = ruleObj.params[2];
 
   let time;
 
   if (ruleObj.params[0].toUpperCase() === NOW) {
-    time = moment();
+    time = dayjs();
 
     messages.push(' now');
   } else {
-    time = moment.unix(ruleObj.params[0]);
+    time = dayjs.unix(ruleObj.params[0]);
 
-    messages.push(` ${moment.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
+    messages.push(` ${dayjs.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
   }
 
   if (offset) {

--- a/src/validators/time-before-or-equal.js
+++ b/src/validators/time-before-or-equal.js
@@ -1,6 +1,10 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
 import join from 'lodash/join';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import 'dayjs/locale/id';
+
+dayjs.extend(isSameOrBefore);
 
 const fullName = 'timeBeforeOrEqual:$1:$2:$3';
 
@@ -18,20 +22,20 @@ const validate = (val, ruleObj) => {
 
   messages = ['<%= propertyName %> must be less than or equal to'];
 
-  const timeInput = moment(val);
+  const timeInput = dayjs(val);
   let offset = Number(ruleObj.params[1]);
   const unit = ruleObj.params[2];
 
   let time;
 
   if (ruleObj.params[0].toUpperCase() === NOW) {
-    time = moment();
+    time = dayjs();
 
     messages.push(' now');
   } else {
-    time = moment.unix(ruleObj.params[0]);
+    time = dayjs.unix(ruleObj.params[0]);
 
-    messages.push(` ${moment.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
+    messages.push(` ${dayjs.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
   }
 
   if (offset) {

--- a/src/validators/time-before.js
+++ b/src/validators/time-before.js
@@ -1,6 +1,10 @@
 import always from 'ramda/src/always';
-import moment from 'moment';
 import join from 'lodash/join';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import 'dayjs/locale/id';
+
+dayjs.extend(utc);
 
 const fullName = 'timeBefore:$1:$2:$3';
 
@@ -18,20 +22,20 @@ const validate = (val, ruleObj) => {
 
   messages = ['<%= propertyName %> must be less than'];
 
-  const timeInput = moment(val);
+  const timeInput = dayjs(val);
   let offset = Number(ruleObj.params[1]);
   const unit = ruleObj.params[2];
 
   let time;
 
   if (ruleObj.params[0].toUpperCase() === NOW) {
-    time = moment();
+    time = dayjs();
 
     messages.push(' now');
   } else {
-    time = moment.unix(ruleObj.params[0]);
+    time = dayjs.unix(ruleObj.params[0]);
 
-    messages.push(` ${moment.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
+    messages.push(` ${dayjs.unix(ruleObj.params[0]).locale('id').utcOffset(7).format('YYYY-MM-DD HH:mm:ssZ')}`);
   }
 
   if (offset) {

--- a/test/validators/date-after-or-equal.spec.js
+++ b/test/validators/date-after-or-equal.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date After Or Equal validator', () => {
   context('given a dateAfterOrEqual rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment().add(1, 'day').format('DD/MM/YYYY');
+      const futureDate = dayjs().add(1, 'day').format('DD/MM/YYYY');
 
       return {
         vacationDate: futureDate
@@ -26,7 +29,7 @@ describe('Date After Or Equal validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('DD/MM/YYYY')
+        vacationDate: dayjs().format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -41,7 +44,7 @@ describe('Date After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment('02-2014', 'MM-YYYY');
+      const futureDate = dayjs('02-2014', 'MM-YYYY');
 
       return {
         vacationDate: futureDate
@@ -58,7 +61,7 @@ describe('Date After Or Equal validator', () => {
 
     it('should not fail when input has the same month', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('01-2014', 'MM-YYYY')
+        vacationDate: dayjs('01-2014', 'MM-YYYY')
       });
       const err = result.messages;
 
@@ -73,7 +76,7 @@ describe('Date After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(364, 'days').format('DD/MM/YYYY');
+      const date = dayjs().subtract(364, 'days').format('DD/MM/YYYY');
 
       return {
         vacationDate: date
@@ -90,7 +93,7 @@ describe('Date After Or Equal validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+        vacationDate: dayjs().subtract(365, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -105,7 +108,7 @@ describe('Date After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(41, 'days').format('DD/MM/YYYY');
+      const date = dayjs().add(41, 'days').format('DD/MM/YYYY');
 
       return {
         vacationDate: date
@@ -122,7 +125,7 @@ describe('Date After Or Equal validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+        vacationDate: dayjs().add(40, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 

--- a/test/validators/date-after.spec.js
+++ b/test/validators/date-after.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date After validator', () => {
   context('given a dateAfter rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment().add(1, 'day').format('DD/MM/YYYY');
+      const futureDate = dayjs().add(1, 'day').format('DD/MM/YYYY');
 
       return {
         vacationDate: futureDate
@@ -26,7 +29,7 @@ describe('Date After validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('DD/MM/YYYY')
+        vacationDate: dayjs().format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -43,7 +46,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment('02-2014', 'MM-YYYY');
+      const futureDate = dayjs('02-2014', 'MM-YYYY');
 
       return {
         vacationDate: futureDate
@@ -60,7 +63,7 @@ describe('Date After validator', () => {
 
     it('should fail when input has the same month', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('01-2014', 'MM-YYYY')
+        vacationDate: dayjs('01-2014', 'MM-YYYY')
       });
       const err = result.messages;
 
@@ -77,7 +80,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(364, 'days').format('DD/MM/YYYY');
+      const date = dayjs().subtract(364, 'days').format('DD/MM/YYYY');
 
       return {
         vacationDate: date
@@ -94,7 +97,7 @@ describe('Date After validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+        vacationDate: dayjs().subtract(365, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -111,7 +114,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(41, 'days').format('DD/MM/YYYY');
+      const date = dayjs().add(41, 'days').format('DD/MM/YYYY');
 
       return {
         vacationDate: date
@@ -128,7 +131,7 @@ describe('Date After validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+        vacationDate: dayjs().add(40, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 

--- a/test/validators/date-before-or-equal.spec.js
+++ b/test/validators/date-before-or-equal.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date Before validator', () => {
   context('given a dateBeforeOrEqual rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().subtract(1, 'day').format('DD/MM/YYYY');
+      const pastDate = dayjs().subtract(1, 'day').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -26,7 +29,7 @@ describe('Date Before validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().format('DD/MM/YYYY')
+        pastVacationDate: dayjs().format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -41,7 +44,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment('12-2013', 'MM-YYYY');
+      const pastDate = dayjs('12-2013', 'MM-YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -58,7 +61,7 @@ describe('Date Before validator', () => {
 
     it('should not fail when input has the same month', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment('01-2014', 'MM-YYYY')
+        pastVacationDate: dayjs('01-2014', 'MM-YYYY')
       });
       const err = result.messages;
 
@@ -73,7 +76,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().subtract(366, 'days').format('DD/MM/YYYY');
+      const pastDate = dayjs().subtract(366, 'days').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -90,7 +93,7 @@ describe('Date Before validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+        pastVacationDate: dayjs().subtract(365, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -105,7 +108,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().add(39, 'days').format('DD/MM/YYYY');
+      const pastDate = dayjs().add(39, 'days').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -122,7 +125,7 @@ describe('Date Before validator', () => {
 
     it('should not fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+        pastVacationDate: dayjs().add(40, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 

--- a/test/validators/date-before.spec.js
+++ b/test/validators/date-before.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date Before validator', () => {
   context('given a dateBefore rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().subtract(1, 'day').format('DD/MM/YYYY');
+      const pastDate = dayjs().subtract(1, 'day').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -26,7 +29,7 @@ describe('Date Before validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().format('DD/MM/YYYY')
+        pastVacationDate: dayjs().format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -43,7 +46,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment('12-2013', 'MM-YYYY');
+      const pastDate = dayjs('12-2013', 'MM-YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -60,7 +63,7 @@ describe('Date Before validator', () => {
 
     it('should fail when input has the same month', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment('01-2014', 'MM-YYYY')
+        pastVacationDate: dayjs('01-2014', 'MM-YYYY')
       });
       const err = result.messages;
 
@@ -77,7 +80,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().subtract(366, 'days').format('DD/MM/YYYY');
+      const pastDate = dayjs().subtract(366, 'days').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -94,7 +97,7 @@ describe('Date Before validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().subtract(365, 'days').format('DD/MM/YYYY')
+        pastVacationDate: dayjs().subtract(365, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 
@@ -111,7 +114,7 @@ describe('Date Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment().add(39, 'days').format('DD/MM/YYYY');
+      const pastDate = dayjs().add(39, 'days').format('DD/MM/YYYY');
 
       return {
         pastVacationDate: pastDate
@@ -128,7 +131,7 @@ describe('Date Before validator', () => {
 
     it('should fail when input has the same date', () => {
       const result = validator.validate(simpleRules, {
-        pastVacationDate: moment().add(40, 'days').format('DD/MM/YYYY')
+        pastVacationDate: dayjs().add(40, 'days').format('DD/MM/YYYY')
       });
       const err = result.messages;
 

--- a/test/validators/date-time-after-or-equal.spec.js
+++ b/test/validators/date-time-after-or-equal.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date After validator', () => {
   context('given a dateTimeAfterOrEqual rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment().add(1, 'minutes').format('YYYYMMDDHHmm');
+      const futureDate = dayjs().add(1, 'minutes').format('YYYYMMDDHHmm');
 
       return {
         vacationDate: futureDate
@@ -26,7 +29,7 @@ describe('Date After validator', () => {
 
     it('should success when input has the same timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('YYYYMMDDHHmm')
+        vacationDate: dayjs().format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -35,7 +38,7 @@ describe('Date After validator', () => {
 
     it('should fail when input before timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(1, 'minutes').format('YYYYMMDDHHmm')
+        vacationDate: dayjs().subtract(1, 'minutes').format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -55,7 +58,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      const futureDate = dayjs('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
 
       return {
         vacationDate: futureDate
@@ -72,7 +75,7 @@ describe('Date After validator', () => {
 
     it('should fail when input is 5 milliseconds faster', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+        vacationDate: dayjs('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
       });
       const err = result.messages;
 
@@ -92,7 +95,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
+      const date = dayjs().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -109,7 +112,7 @@ describe('Date After validator', () => {
 
     it('should fail when input is 6 seconds ago', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
+        vacationDate: dayjs().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 
@@ -129,7 +132,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(11, 'minutes').format('YYYY-MM-DDTHH:mm');
+      const date = dayjs().add(11, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -146,7 +149,7 @@ describe('Date After validator', () => {
 
     it('should fail when input 9 minutes after now', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(9, 'minutes').format('YYYY-MM-DDTHH:mm')
+        vacationDate: dayjs().add(9, 'minutes').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 

--- a/test/validators/date-time-after.spec.js
+++ b/test/validators/date-time-after.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date After validator', () => {
   context('given a dateTimeAfter rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment().add(1, 'minutes').format('YYYYMMDDHHmm');
+      const futureDate = dayjs().add(1, 'minutes').format('YYYYMMDDHHmm');
 
       return {
         vacationDate: futureDate
@@ -26,7 +29,7 @@ describe('Date After validator', () => {
 
     it('should fail when input has the same timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('YYYYMMDDHHmm')
+        vacationDate: dayjs().format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -46,7 +49,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      const futureDate = dayjs('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
 
       return {
         vacationDate: futureDate
@@ -63,7 +66,7 @@ describe('Date After validator', () => {
 
     it('should fail when input is 5 milliseconds ago', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+        vacationDate: dayjs('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
       });
       const err = result.messages;
 
@@ -83,7 +86,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
+      const date = dayjs().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -100,7 +103,7 @@ describe('Date After validator', () => {
 
     it('should fail when input is 5 seconds ago', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(5, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
+        vacationDate: dayjs().subtract(5, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 
@@ -120,7 +123,7 @@ describe('Date After validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(11, 'minutes').format('YYYY-MM-DDTHH:mm');
+      const date = dayjs().add(11, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -137,7 +140,7 @@ describe('Date After validator', () => {
 
     it('should fail when input is 10 minutes after now', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(10, 'minutes').format('YYYY-MM-DDTHH:mm')
+        vacationDate: dayjs().add(10, 'minutes').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 

--- a/test/validators/date-time-before-or-equal.spec.js
+++ b/test/validators/date-time-before-or-equal.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date Time Before Or Equal validator', () => {
   context('given a dateTimeBeforeOrEqual rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const passDate = moment().subtract(1, 'minutes').format('YYYYMMDDHHmm');
+      const passDate = dayjs().subtract(1, 'minutes').format('YYYYMMDDHHmm');
 
       return {
         vacationDate: passDate
@@ -26,7 +29,7 @@ describe('Date Time Before Or Equal validator', () => {
 
     it('should success when input has the same timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('YYYYMMDDHHmm')
+        vacationDate: dayjs().format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -35,7 +38,7 @@ describe('Date Time Before Or Equal validator', () => {
 
     it('should fail when input after timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(1, 'minutes').format('YYYYMMDDHHmm')
+        vacationDate: dayjs().add(1, 'minutes').format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -55,7 +58,7 @@ describe('Date Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const passDate = moment('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      const passDate = dayjs('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
 
       return {
         vacationDate: passDate
@@ -72,7 +75,7 @@ describe('Date Time Before Or Equal validator', () => {
 
     it('should fail when input is 5 milliseconds later', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+        vacationDate: dayjs('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
       });
       const err = result.messages;
 
@@ -92,7 +95,7 @@ describe('Date Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
+      const date = dayjs().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -109,7 +112,7 @@ describe('Date Time Before Or Equal validator', () => {
 
     it('should fail when input is 4 seconds ago', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
+        vacationDate: dayjs().subtract(4, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 
@@ -129,7 +132,7 @@ describe('Date Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(9, 'minutes').format('YYYY-MM-DDTHH:mm');
+      const date = dayjs().add(9, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -146,7 +149,7 @@ describe('Date Time Before Or Equal validator', () => {
 
     it('should fail when input 11 minutes after now', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(11, 'minutes').format('YYYY-MM-DDTHH:mm')
+        vacationDate: dayjs().add(11, 'minutes').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 

--- a/test/validators/date-time-before.spec.js
+++ b/test/validators/date-time-before.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import validator from '../../lib';
+
+dayjs.extend(customParseFormat);
 
 describe('Date Time Before validator', () => {
   context('given a dateTimeBefore rule with parameter `now`', () => {
@@ -9,7 +12,7 @@ describe('Date Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const futureDate = moment().subtract(1, 'minutes').format('YYYYMMDDHHmm');
+      const futureDate = dayjs().subtract(1, 'minutes').format('YYYYMMDDHHmm');
 
       return {
         vacationDate: futureDate
@@ -26,7 +29,7 @@ describe('Date Time Before validator', () => {
 
     it('should fail when input has the same timestamp', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().format('YYYYMMDDHHmm')
+        vacationDate: dayjs().format('YYYYMMDDHHmm')
       });
       const err = result.messages;
 
@@ -46,7 +49,7 @@ describe('Date Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastDate = moment('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      const pastDate = dayjs('2015-05-12T10:45:00.550+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]');
 
       return {
         vacationDate: pastDate
@@ -63,7 +66,7 @@ describe('Date Time Before validator', () => {
 
     it('should fail when input is 5 milliseconds later', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
+        vacationDate: dayjs('2015-05-12T10:45:00.560+07', 'YYYY-MM-DDTHH:mm:ss.SSS[Z]')
       });
       const err = result.messages;
 
@@ -83,7 +86,7 @@ describe('Date Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
+      const date = dayjs().subtract(6, 'seconds').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -100,7 +103,7 @@ describe('Date Time Before validator', () => {
 
     it('should fail when input is 5 seconds after', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(5, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
+        vacationDate: dayjs().add(5, 'seconds').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 
@@ -120,7 +123,7 @@ describe('Date Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const date = moment().add(9, 'minutes').format('YYYY-MM-DDTHH:mm');
+      const date = dayjs().add(9, 'minutes').format('YYYY-MM-DDTHH:mm:ss');
 
       return {
         vacationDate: date
@@ -137,7 +140,7 @@ describe('Date Time Before validator', () => {
 
     it('should fail when input is 10 minutes after now', () => {
       const result = validator.validate(rules, {
-        vacationDate: moment().add(10, 'minutes').format('YYYY-MM-DDTHH:mm')
+        vacationDate: dayjs().add(10, 'minutes').format('YYYY-MM-DDTHH:mm:ss')
       });
       const err = result.messages;
 

--- a/test/validators/minimum-age.spec.js
+++ b/test/validators/minimum-age.spec.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import dayjs from 'dayjs';
 import {expect} from 'chai';
 import validator from '../../lib';
 
@@ -8,7 +8,7 @@ describe ('MinimumAge validator', () => {
   };
 
   context('given valid age', () => {
-    const birthDate = moment()
+    const birthDate = dayjs()
             .subtract(21, 'years')
             .format('DD/MM/YYYY');
 
@@ -26,7 +26,7 @@ describe ('MinimumAge validator', () => {
   });
 
   context('given invalid age', () => {
-    const birthDate = moment()
+    const birthDate = dayjs()
       .subtract(21, 'years')
       .add(2, 'day')
       .format('DD/MM/YYYY');

--- a/test/validators/time-after-or-equal.spec.js
+++ b/test/validators/time-after-or-equal.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import validator from '../../lib';
 
 describe('Time After Or Equal validator', () => {
@@ -9,7 +9,7 @@ describe('Time After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const futureTime = moment().add(1, 'seconds');
+      const futureTime = dayjs().add(1, 'seconds');
 
       return {
         vacationTime: futureTime
@@ -26,7 +26,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should fail when input has slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().subtract(1, 'seconds')
+        vacationTime: dayjs().subtract(1, 'seconds')
       });
       const err = result.messages;
 
@@ -43,7 +43,7 @@ describe('Time After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const futureTime = moment('2019-06-03T08:22:02Z');
+      const futureTime = dayjs('2019-06-03T08:22:02Z');
 
       return {
         vacationTime: futureTime
@@ -60,7 +60,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:01Z')
+        vacationTime: dayjs('2019-06-03T08:22:01Z')
       });
       const err = result.messages;
 
@@ -75,7 +75,7 @@ describe('Time After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().subtract(30, 'minutes').add(1, 'seconds');
+      const time = dayjs().subtract(30, 'minutes').add(1, 'seconds');
 
       return {
         vacationTime: time
@@ -92,7 +92,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should fail when input has slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().subtract(30, 'minutes').subtract(1, 'seconds')
+        vacationTime: dayjs().subtract(30, 'minutes').subtract(1, 'seconds')
       });
       const err = result.messages;
 
@@ -109,7 +109,7 @@ describe('Time After Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().add(31, 'seconds');
+      const time = dayjs().add(31, 'seconds');
 
       return {
         vacationTime: time
@@ -126,7 +126,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should fail when input has slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().add(29, 'seconds')
+        vacationTime: dayjs().add(29, 'seconds')
       });
       const err = result.messages;
 
@@ -144,7 +144,7 @@ describe('Time After Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:12:02Z')
+        vacationTime: dayjs('2019-06-03T08:12:02Z')
       };
     };
 
@@ -158,7 +158,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:12:01Z')
+        vacationTime: dayjs('2019-06-03T08:12:01Z')
       });
       const err = result.messages;
 
@@ -174,7 +174,7 @@ describe('Time After Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:22:12Z')
+        vacationTime: dayjs('2019-06-03T08:22:12Z')
       };
     };
 
@@ -188,7 +188,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:11Z')
+        vacationTime: dayjs('2019-06-03T08:22:11Z')
       });
       const err = result.messages;
 
@@ -204,7 +204,7 @@ describe('Time After Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2019-06-03T13:22:02Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:02Z')
       };
     };
 
@@ -218,7 +218,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2019-06-03T13:22:01Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:01Z')
       });
       const err = result.messages;
 
@@ -234,7 +234,7 @@ describe('Time After Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2015-06-03T08:22:02Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:02Z')
       };
     };
 
@@ -248,7 +248,7 @@ describe('Time After Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2015-06-03T08:22:01Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:01Z')
       });
       const err = result.messages;
 

--- a/test/validators/time-after.spec.js
+++ b/test/validators/time-after.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import validator from '../../lib';
 
 describe('Time After validator', () => {
@@ -9,7 +9,7 @@ describe('Time After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureTime = moment().add(1, 'seconds');
+      const futureTime = dayjs().add(1, 'seconds');
 
       return {
         vacationTime: futureTime
@@ -26,7 +26,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time or slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment()
+        vacationTime: dayjs()
       });
       const err = result.messages;
 
@@ -43,7 +43,7 @@ describe('Time After validator', () => {
     };
 
     const getTestObject = () => {
-      const futureTime = moment('2019-06-03T08:22:02Z');
+      const futureTime = dayjs('2019-06-03T08:22:02Z');
 
       return {
         vacationTime: futureTime
@@ -60,7 +60,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:01Z')
+        vacationTime: dayjs('2019-06-03T08:22:01Z')
       });
       const err = result.messages;
 
@@ -77,7 +77,7 @@ describe('Time After validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().subtract(30, 'minutes').add(1, 'seconds');
+      const time = dayjs().subtract(30, 'minutes').add(1, 'seconds');
 
       return {
         vacationTime: time
@@ -94,7 +94,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time or slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().subtract(30, 'minutes')
+        vacationTime: dayjs().subtract(30, 'minutes')
       });
       const err = result.messages;
 
@@ -111,7 +111,7 @@ describe('Time After validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().add(31, 'seconds');
+      const time = dayjs().add(31, 'seconds');
 
       return {
         vacationTime: time
@@ -128,7 +128,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time or slightly older time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().add(30, 'seconds')
+        vacationTime: dayjs().add(30, 'seconds')
       });
       const err = result.messages;
 
@@ -146,7 +146,7 @@ describe('Time After validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:12:02Z')
+        vacationTime: dayjs('2019-06-03T08:12:02Z')
       };
     };
 
@@ -160,7 +160,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:12:01Z')
+        vacationTime: dayjs('2019-06-03T08:12:01Z')
       });
       const err = result.messages;
 
@@ -178,7 +178,7 @@ describe('Time After validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:22:12Z')
+        vacationTime: dayjs('2019-06-03T08:22:12Z')
       };
     };
 
@@ -192,7 +192,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:11Z')
+        vacationTime: dayjs('2019-06-03T08:22:11Z')
       });
       const err = result.messages;
 
@@ -210,7 +210,7 @@ describe('Time After validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2019-06-03T13:22:02Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:02Z')
       };
     };
 
@@ -224,7 +224,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2019-06-03T13:22:01Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:01Z')
       });
       const err = result.messages;
 
@@ -242,7 +242,7 @@ describe('Time After validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2015-06-03T08:22:02Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:02Z')
       };
     };
 
@@ -256,7 +256,7 @@ describe('Time After validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2015-06-03T08:22:01Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:01Z')
       });
       const err = result.messages;
 

--- a/test/validators/time-before-or-equal.spec.js
+++ b/test/validators/time-before-or-equal.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import validator from '../../lib';
 
 describe('Time Before Or Equal validator', () => {
@@ -9,7 +9,7 @@ describe('Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const pastTime = moment().subtract(1, 'seconds');
+      const pastTime = dayjs().subtract(1, 'seconds');
 
       return {
         vacationTime: pastTime
@@ -26,7 +26,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().add(1, 'seconds')
+        vacationTime: dayjs().add(1, 'seconds')
       });
       const err = result.messages;
 
@@ -43,7 +43,7 @@ describe('Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const pastTime = moment('2019-06-03T08:22:00Z');
+      const pastTime = dayjs('2019-06-03T08:22:00Z');
 
       return {
         vacationTime: pastTime
@@ -60,7 +60,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:01Z')
+        vacationTime: dayjs('2019-06-03T08:22:01Z')
       });
       const err = result.messages;
 
@@ -70,7 +70,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should  fail when input has more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:02Z')
+        vacationTime: dayjs('2019-06-03T08:22:02Z')
       });
       const err = result.messages;
 
@@ -85,7 +85,7 @@ describe('Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().subtract(30, 'minutes').subtract(1, 'seconds');
+      const time = dayjs().subtract(30, 'minutes').subtract(1, 'seconds');
 
       return {
         vacationTime: time
@@ -102,7 +102,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().subtract(30, 'minutes').add(1, 'second'),
+        vacationTime: dayjs().subtract(30, 'minutes').add(1, 'second'),
       });
       const err = result.messages;
 
@@ -119,7 +119,7 @@ describe('Time Before Or Equal validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().add(29, 'seconds');
+      const time = dayjs().add(29, 'seconds');
 
       return {
         vacationTime: time
@@ -136,7 +136,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().add(31, 'seconds')
+        vacationTime: dayjs().add(31, 'seconds')
       });
       const err = result.messages;
 
@@ -154,7 +154,7 @@ describe('Time Before Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:12:00Z')
+        vacationTime: dayjs('2019-06-03T08:12:00Z')
       };
     };
 
@@ -168,7 +168,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:12:01Z')
+        vacationTime: dayjs('2019-06-03T08:12:01Z')
       });
       const err = result.messages;
 
@@ -178,7 +178,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:12:02Z')
+        vacationTime: dayjs('2019-06-03T08:12:02Z')
       });
       const err = result.messages;
 
@@ -194,7 +194,7 @@ describe('Time Before Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:22:10Z')
+        vacationTime: dayjs('2019-06-03T08:22:10Z')
       };
     };
 
@@ -208,7 +208,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:11Z')
+        vacationTime: dayjs('2019-06-03T08:22:11Z')
       });
       const err = result.messages;
 
@@ -218,7 +218,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:12Z')
+        vacationTime: dayjs('2019-06-03T08:22:12Z')
       });
       const err = result.messages;
 
@@ -234,7 +234,7 @@ describe('Time Before Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2019-06-03T13:22:00Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:00Z')
       };
     };
 
@@ -248,7 +248,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2019-06-03T13:22:01Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:01Z')
       });
       const err = result.messages;
 
@@ -258,7 +258,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has more recent time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2019-06-03T13:22:02Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:02Z')
       });
       const err = result.messages;
 
@@ -274,7 +274,7 @@ describe('Time Before Or Equal validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2015-06-03T08:22:00Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:00Z')
       };
     };
 
@@ -288,7 +288,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should not fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2015-06-03T08:22:01Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:01Z')
       });
       const err = result.messages;
 
@@ -298,7 +298,7 @@ describe('Time Before Or Equal validator', () => {
 
     it('should fail when input has more recent time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2015-06-03T08:22:02Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:02Z')
       });
       const err = result.messages;
 

--- a/test/validators/time-before.spec.js
+++ b/test/validators/time-before.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import dayjs from 'dayjs';
 import validator from '../../lib';
 
 describe('Time Before validator', () => {
@@ -9,7 +9,7 @@ describe('Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastTime = moment().subtract(1, 'seconds');
+      const pastTime = dayjs().subtract(1, 'seconds');
 
       return {
         vacationTime: pastTime
@@ -26,7 +26,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time or slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment()
+        vacationTime: dayjs()
       });
       const err = result.messages;
 
@@ -43,7 +43,7 @@ describe('Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const pastTime = moment('2019-06-03T08:22:00Z');
+      const pastTime = dayjs('2019-06-03T08:22:00Z');
 
       return {
         vacationTime: pastTime
@@ -60,7 +60,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:01Z')
+        vacationTime: dayjs('2019-06-03T08:22:01Z')
       });
       const err = result.messages;
 
@@ -77,7 +77,7 @@ describe('Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().subtract(30, 'minutes').subtract(1, 'seconds');
+      const time = dayjs().subtract(30, 'minutes').subtract(1, 'seconds');
 
       return {
         vacationTime: time
@@ -94,7 +94,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time or slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().subtract(30, 'minutes').add(1, 'second'),
+        vacationTime: dayjs().subtract(30, 'minutes').add(1, 'second'),
       });
       const err = result.messages;
 
@@ -111,7 +111,7 @@ describe('Time Before validator', () => {
     };
 
     const getTestObject = () => {
-      const time = moment().add(29, 'seconds');
+      const time = dayjs().add(29, 'seconds');
 
       return {
         vacationTime: time
@@ -128,7 +128,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time or slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment().add(30, 'seconds').add(1, 'second'),
+        vacationTime: dayjs().add(30, 'seconds').add(1, 'second'),
       });
       const err = result.messages;
 
@@ -146,7 +146,7 @@ describe('Time Before validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:12:00Z')
+        vacationTime: dayjs('2019-06-03T08:12:00Z')
       };
     };
 
@@ -160,7 +160,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:12:01Z')
+        vacationTime: dayjs('2019-06-03T08:12:01Z')
       });
       const err = result.messages;
 
@@ -178,7 +178,7 @@ describe('Time Before validator', () => {
 
     const getTestObject = () => {
       return {
-        vacationTime: moment('2019-06-03T08:22:09Z')
+        vacationTime: dayjs('2019-06-03T08:22:09Z')
       };
     };
 
@@ -192,7 +192,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        vacationTime: moment('2019-06-03T08:22:11Z')
+        vacationTime: dayjs('2019-06-03T08:22:11Z')
       });
       const err = result.messages;
 
@@ -210,7 +210,7 @@ describe('Time Before validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2019-06-03T13:22:00Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:00Z')
       };
     };
 
@@ -224,7 +224,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2019-06-03T13:22:01Z')
+        pastVacationTime: dayjs('2019-06-03T13:22:01Z')
       });
       const err = result.messages;
 
@@ -242,7 +242,7 @@ describe('Time Before validator', () => {
 
     const getTestObject = () => {
       return {
-        pastVacationTime: moment('2015-06-03T08:22:00Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:00Z')
       };
     };
 
@@ -256,7 +256,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time', () => {
       const result = validator.validate(rules, {
-        pastVacationTime: moment('2015-06-03T08:22:01Z')
+        pastVacationTime: dayjs('2015-06-03T08:22:01Z')
       });
       const err = result.messages;
 

--- a/test/validators/time-before.spec.js
+++ b/test/validators/time-before.spec.js
@@ -26,7 +26,7 @@ describe('Time Before validator', () => {
 
     it('should fail when input has the same time or slightly more recent time', () => {
       const result = validator.validate(rules, {
-        vacationTime: dayjs()
+        vacationTime: dayjs().add(1, 'seconds')
       });
       const err = result.messages;
 


### PR DESCRIPTION
Compared to moment, dayjs is significantly smaller (73.1 kB vs 3 kB minified & gzipped) while still having similar date APIs. This should help reduce client bundle size for our front end projects which use cermati utils.

This change introduces a breaking behavior regarding invalid date input format.
Previously, parsing an incomplete input date using moment will fill the missing value. dayjs doesn't have this behavior. Considering adding `date-format` validation if your input is not guaranteed to have a valid format.
```
const dateWithoutSeconds = '2024-05-07T13:00';
const dateFormatExpectingSeconds = 'YYYY-MM-DDTHH:mm:ss';

moment(dateWithoutSeconds, dateFormatExpectingSeconds).format()
> '2024-05-07T13:00:00+07:00'

dayjs(dateWithoutSeconds, dateFormatExpectingSeconds).format()
> 'Invalid Date'
```