### PR TITLE
feat(validators): add mustInclude validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ const result = customValidator.validate(
 - `indonesianName`
 
   [examples](https://github.com/cermati/satpam/blob/master/test/validators/indonesian-name.spec.js#L6)
+- `mustInclude` Check if the given value has all of the items in the list
+
+  [examples](https://github.com/cermati/satpam/blob/master/test/validators/must-include.spec.js#L8)
 
 
 ## Complete Examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satpam",
-  "version": "4.13.0",
+  "version": "4.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.13.0",
+      "version": "4.16.0",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -35,6 +35,7 @@ import minValue from '../validators/min-value';
 import minimumAge from '../validators/minimum-age';
 import mobilePhoneNumber from '../validators/mobile-phone-number';
 import mongoId from '../validators/mongo-id';
+import mustInclude from '../validators/must-include';
 import nonBlank from '../validators/non-blank';
 import notDisposableEmail from '../validators/not-disposable-email';
 import notEqual from '../validators/not-equal';
@@ -94,6 +95,7 @@ let validators = [
   minimumAge,
   mobilePhoneNumber,
   mongoId,
+  mustInclude,
   nonBlank,
   notDisposableEmail,
   notEqual,

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ import minimumAge from './validators/minimum-age';
 import mobilePhoneNumber from './validators/mobile-phone-number';
 import mongoId from './validators/mongo-id';
 import multipleOf from './validators/multiple-of';
+import mustInclude from './validators/must-include';
 import nonBlank from './validators/non-blank';
 import notDisposableEmail from './validators/not-disposable-email';
 import notEqual from './validators/not-equal';
@@ -135,6 +136,7 @@ let validators = [
   mobilePhoneNumber,
   mongoId,
   multipleOf,
+  mustInclude,
   nonBlank,
   notDisposableEmail,
   notEqual,

--- a/src/validators/must-include.js
+++ b/src/validators/must-include.js
@@ -1,0 +1,20 @@
+import is from 'ramda/src/is';
+import isNil from 'ramda/src/isNil';
+import all from 'ramda/src/all';
+
+const fullName = 'mustInclude:$1';
+
+const validate = (val, ruleObj) => {
+  if (isNil(val)) {
+    return true;
+  }
+
+  const valArray = is(Array, val) ? val : [val];
+  const list = ruleObj.params[0];
+
+  return all(item => valArray.includes(item), list);
+};
+
+const message = '<%= propertyName %> must include all of <%= ruleParams[0] %>.';
+
+export default { fullName, validate, message };

--- a/test/validators/must-include.spec.js
+++ b/test/validators/must-include.spec.js
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MustInclude validator', () => {
+  const objectRules = {
+    item: [
+      {
+        name: 'mustInclude', params: [['A', 'C']]
+      }
+    ]
+  };
+
+  it('should success if inputs have the required items', () => {
+    const acceptedInputs = [
+      ['A', 'C'],
+      ['A', 'B', 'C']
+    ];
+
+    acceptedInputs.forEach(function test(acceptedInput) {
+      const result = validator.validate(objectRules, {item: acceptedInput});
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('item');
+    });
+  });
+
+  it('should fail if inputs only have some of the required items', () => {
+    const rejectedInputs = [
+      ['A', 'B'],
+      ['A', 'B', 'D'],
+    ];
+
+    rejectedInputs.forEach(function test(rejectedInput) {
+      const result = validator.validate(objectRules, {item: rejectedInput});
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('item');
+      expect(err.item['mustInclude:$1']).to.equal('Item must include all of A,C.');
+    });
+  });
+
+  it('should fail if inputs have none of the required items', () => {
+    const rejectedInputs = [
+      'B',
+      ['B', 'D'],
+    ];
+
+    rejectedInputs.forEach(function test(rejectedInput) {
+      const result = validator.validate(objectRules, {item: rejectedInput});
+      const err = result.messages;
+
+      expect(result.success).to.equal(false);
+      expect(err).to.have.property('item');
+      expect(err.item['mustInclude:$1']).to.equal('Item must include all of A,C.');
+    });
+  });
+
+});

--- a/test/validators/must-include.spec.js
+++ b/test/validators/must-include.spec.js
@@ -10,10 +10,22 @@ describe('MustInclude validator', () => {
     ]
   };
 
+  it('should success if an empty array is passed', () => {
+    const acceptedInputs = [];
+
+    acceptedInputs.forEach(function test(acceptedInput) {
+      const result = validator.validate(objectRules, {item: acceptedInput});
+      const err = result.messages;
+
+      expect(result.success).to.equal(true);
+      expect(err).to.not.have.property('item');  
+    })
+  })
+
   it('should success if inputs have the required items', () => {
     const acceptedInputs = [
       ['A', 'C'],
-      ['A', 'B', 'C']
+      ['A', 'B', 'C'],
     ];
 
     acceptedInputs.forEach(function test(acceptedInput) {


### PR DESCRIPTION
Example Case:
Rules: must include (Item A, Item C)

Expected Behavior:
Order Items: [A, B, C] -> Valid (TRUE) (Because both A and C are present) Order Items: [A, B, D] -> Not Valid (FALSE) (Because only A is present, C is missing) Order Items: [B, D] -> Not Valid (FALSE) (Because both A and C are missing)