### PR TITLE
feat(validators): added ISO duration, minDuration, and maxDuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "satpam",
-  "version": "4.16.0",
+  "version": "4.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.16.0",
+      "version": "4.19.0",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",
         "image-type": "~4.1.0",
         "lodash": "~4.17.21",
+        "luxon": "~3.7.2",
         "moment": "~2.29.4",
         "noes": "~1.1.1",
         "ramda": "~0.25.0",
@@ -4539,6 +4540,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -9860,6 +9869,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {
@@ -25,6 +25,7 @@
     "file-type": "~3.8.0",
     "image-type": "~4.1.0",
     "lodash": "~4.17.21",
+    "luxon": "~3.7.2",
     "moment": "~2.29.4",
     "noes": "~1.1.1",
     "ramda": "~0.25.0",

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -58,6 +58,10 @@ import Validator from './validator';
 import reduce from 'lodash/reduce';
 import mustHaveAllPrefixes from '../validators/must-have-all-prefixes';
 
+import duration from '../validators/duration';
+import minDuration from '../validators/min-duration';
+import maxDuration from '../validators/max-duration';
+
 let validators = [
   alpha,
   alphanumeric,
@@ -74,6 +78,7 @@ let validators = [
   dateFormat,
   dateTimeAfter,
   dateTimeAfterOrEqual,
+  duration,
   email,
   emptyString,
   equal,
@@ -88,9 +93,11 @@ let validators = [
   imei,
   integer,
   length,
+  maxDuration,
   maxLength,
   maxValue,
   memberOf,
+  minDuration,
   minLength,
   minValue,
   minimumAge,

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,9 @@ import url from './validators/url';
 import urlProtocol from './validators/url-protocol';
 import uuid from './validators/uuid';
 import mustHaveAllPrefixes from './validators/must-have-all-prefixes';
+import duration from './validators/duration';
+import minDuration from './validators/min-duration';
+import maxDuration from './validators/max-duration';
 
 let validators = [
   alpha,
@@ -110,6 +113,7 @@ let validators = [
   dateTimeBefore,
   dateTimeBeforeOrEqual,
   dateFormat,
+  duration,
   email,
   emptyString,
   equal,
@@ -128,9 +132,11 @@ let validators = [
   internationalPhoneNumber,
   ip,
   length,
+  maxDuration,
   maxLength,
   maxValue,
   memberOf,
+  minDuration,
   minLength,
   minValue,
   minimumAge,

--- a/src/validators/duration.js
+++ b/src/validators/duration.js
@@ -1,0 +1,41 @@
+import {Duration} from 'luxon';
+
+const fullName = 'duration';
+
+/**
+ * ISO 8601 duration format
+ *
+ * ISO 8601 Durations are expressed using the following format, where (n) is
+ * replaced by the value for each of the date and time elements that follow the (n):
+ *
+ * **P(n)Y(n)M(n)DT(n)H(n)M(n)S**
+ *
+ * Where:
+ * *  P is the duration designator (referred to as "period"), and is always placed at the beginning of the duration.
+ * *  Y is the year designator that follows the value for the number of years.
+ * *  M is the month designator that follows the value for the number of months.
+ * *  W is the week designator that follows the value for the number of weeks.
+ * *  D is the day designator that follows the value for the number of days.
+ * *  T is the time designator that precedes the time components.
+ * *  H is the hour designator that follows the value for the number of hours.
+ * *  M is the minute designator that follows the value for the number of minutes.
+ * *  S is the second designator that follows the value for the number of seconds.
+ *
+ * For example:
+ * * PT10S represents a duration of 10 seconds.
+ * * PT15M represents a duration of 15 minutes.
+ * * PT2H15M30S represents a duration of 2 hours, 15 minutes, and 30 seconds.
+ * * PT0.1S represents a duration of 100 milliseconds.
+ * * P3Y6M4DT12H30M5S represents a duration of 3 years, 6 months, 4 days, 12 hours, 30 minutes, and 5 seconds.
+ */
+const validate = val => {
+  if (!val) {
+    return true;
+  }
+
+  return Duration.fromISO(val).isValid;
+};
+
+const message = '<%= propertyName %> must be a valid ISO 8601 duration.';
+
+export default {fullName, validate, message};

--- a/src/validators/max-duration.js
+++ b/src/validators/max-duration.js
@@ -1,0 +1,22 @@
+import { Duration } from 'luxon';
+
+const fullName = 'maxDuration:$1';
+
+const validate = (val, ruleObj) => {
+  if (!val) {
+    return true;
+  }
+
+  const duration = Duration.fromISO(val);
+  const max = Duration.fromISO(ruleObj.params[0]);
+
+  if (!duration.isValid || !max.isValid) {
+    return false;
+  }
+
+  return duration.toMillis() <= max.toMillis();
+};
+
+const message = '<%= propertyName %> must be at most <%= ruleParams[0] %>.';
+
+export default { fullName, validate, message };

--- a/src/validators/min-duration.js
+++ b/src/validators/min-duration.js
@@ -1,0 +1,22 @@
+import { Duration } from 'luxon';
+
+const fullName = 'minDuration:$1';
+
+const validate = (val, ruleObj) => {
+  if (!val) {
+    return true;
+  }
+
+  const duration = Duration.fromISO(val);
+  const max = Duration.fromISO(ruleObj.params[0]);
+
+  if (!duration.isValid || !max.isValid) {
+    return false;
+  }
+
+  return duration.toMillis() >= max.toMillis();
+};
+
+const message = '<%= propertyName %> must be at least <%= ruleParams[0] %>.';
+
+export default { fullName, validate, message };

--- a/test/validators/duration.spec.js
+++ b/test/validators/duration.spec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('Duration validator', () => {
+  const rules = {
+    schedule: ['duration']
+  };
+
+  it('should success with valid ISO 8601 duration', () => {
+    const result = validator.validate(rules, { schedule: 'P1Y2M3DT4H5M6S' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+
+  it('should success with empty value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: '' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with null value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should fail with invalid ISO 8601 duration', () => {
+    const result = validator.validate(rules, { schedule: 'invalid-duration' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+    expect(err.schedule.duration).to.include('Schedule must be a valid ISO 8601 duration.');
+  });
+
+  it('should fail with a plain number string', () => {
+    const result = validator.validate(rules, { schedule: '12345' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+    expect(err.schedule.duration).to.include('Schedule must be a valid ISO 8601 duration.');
+  });
+
+  it('should success with duration in weeks format', () => {
+    const result = validator.validate(rules, { schedule: 'P3W' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with time-only duration', () => {
+    const result = validator.validate(rules, { schedule: 'PT4H30M' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with duration in millisecond format', () => {
+    const result = validator.validate(rules, { schedule: 'PT0.1S' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+});

--- a/test/validators/max-duration.spec.js
+++ b/test/validators/max-duration.spec.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MaxDuration validator', () => {
+  const rules = {
+    schedule: ['maxDuration:PT1H']
+  };
+
+  it('should success with duration equal to maximum', () => {
+    const result = validator.validate(rules, { schedule: 'PT1H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with duration less than maximum', () => {
+    const result = validator.validate(rules, { schedule: 'PT30M' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should fail with duration greater than maximum', () => {
+    const result = validator.validate(rules, { schedule: 'PT3H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+    expect(err.schedule['maxDuration:$1']).to.include('Schedule must be at most PT1H.');
+  });
+
+  it('should success with empty value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: '' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with null value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should fail with invalid duration value', () => {
+    const result = validator.validate(rules, { schedule: 'invalid-duration' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+  });
+
+  it('should fail with invalid maximum param', () => {
+    const invalidParamRules = {
+      schedule: ['maxDuration:invalid-param']
+    };
+    const result = validator.validate(invalidParamRules, { schedule: 'PT1H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+  });
+
+  it('should fail with larger unit exceeding maximum', () => {
+    const result = validator.validate(rules, { schedule: 'P1D' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+  });
+});

--- a/test/validators/min-duration.spec.js
+++ b/test/validators/min-duration.spec.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MinDuration validator', () => {
+  const rules = {
+    schedule: ['minDuration:PT1H']
+  };
+
+  it('should success with duration equal to minimum', () => {
+    const result = validator.validate(rules, { schedule: 'PT1H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with duration greater than minimum', () => {
+    const result = validator.validate(rules, { schedule: 'PT2H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should fail with duration less than minimum', () => {
+    const result = validator.validate(rules, { schedule: 'PT30M' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+    expect(err.schedule['minDuration:$1']).to.include('Schedule must be at least PT1H.');
+  });
+
+  it('should success with empty value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: '' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should success with null value (optional field)', () => {
+    const result = validator.validate(rules, { schedule: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+
+  it('should fail with invalid duration value', () => {
+    const result = validator.validate(rules, { schedule: 'invalid-duration' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+  });
+
+  it('should fail with invalid minimum param', () => {
+    const invalidParamRules = {
+      schedule: ['minDuration:invalid-param']
+    };
+    const result = validator.validate(invalidParamRules, { schedule: 'PT1H' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
+  });
+
+  it('should success with larger unit exceeding minimum', () => {
+    const result = validator.validate(rules, { schedule: 'P1D' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
+  });
+});


### PR DESCRIPTION
Add three new validators to support ISO 8601 duration format validation: 
 - duration: checks if a value is a valid ISO 8601 duration string
 - minDuration: checks if a duration meets a specified minimum
 - maxDuration: checks if a duration does not exceed a specified maximum
 - unit tests

example usage for minimum 1 second and max 10 minutes
```
rules = {
  timeoutDuration: ['duration', 'minDuration:PT1S', 'maxDuration:PT10M']
};
```

For example:
 - PT10S represents a duration of 10 seconds.
 - PT15M represents a duration of 15 minutes.
 - PT2H15M30S represents a duration of 2 hours, 15 minutes, and 30 seconds.
 - PT0.1S represents a duration of 100 milliseconds.
 - P3Y6M4DT12H30M5S represents a duration of 3 years, 6 months, 4 days, 12 hours, 30 minutes, and 5 seconds.