### PR TITLE
feat(validators): rename duration to include iso8601 prefixes

### DIFF
--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -58,9 +58,9 @@ import Validator from './validator';
 import reduce from 'lodash/reduce';
 import mustHaveAllPrefixes from '../validators/must-have-all-prefixes';
 
-import duration from '../validators/duration';
-import minDuration from '../validators/min-duration';
-import maxDuration from '../validators/max-duration';
+import iso8601Duration from '../validators/iso-8601-duration';
+import iso8601MinDuration from '../validators/iso-8601-min-duration';
+import iso8601MaxDuration from '../validators/iso-8601-max-duration';
 
 let validators = [
   alpha,
@@ -78,7 +78,6 @@ let validators = [
   dateFormat,
   dateTimeAfter,
   dateTimeAfterOrEqual,
-  duration,
   email,
   emptyString,
   equal,
@@ -92,12 +91,13 @@ let validators = [
   ip,
   imei,
   integer,
+  iso8601Duration,
+  iso8601MinDuration,
+  iso8601MaxDuration,
   length,
-  maxDuration,
   maxLength,
   maxValue,
   memberOf,
-  minDuration,
   minLength,
   minValue,
   minimumAge,

--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,9 @@ import url from './validators/url';
 import urlProtocol from './validators/url-protocol';
 import uuid from './validators/uuid';
 import mustHaveAllPrefixes from './validators/must-have-all-prefixes';
-import duration from './validators/duration';
-import minDuration from './validators/min-duration';
-import maxDuration from './validators/max-duration';
+import iso8601Duration from './validators/iso-8601-duration';
+import iso8601MinDuration from './validators/iso-8601-min-duration';
+import iso8601MaxDuration from './validators/iso-8601-max-duration';
 
 let validators = [
   alpha,
@@ -113,7 +113,6 @@ let validators = [
   dateTimeBefore,
   dateTimeBeforeOrEqual,
   dateFormat,
-  duration,
   email,
   emptyString,
   equal,
@@ -131,12 +130,13 @@ let validators = [
   integer,
   internationalPhoneNumber,
   ip,
+  iso8601Duration,
+  iso8601MinDuration,
+  iso8601MaxDuration,
   length,
-  maxDuration,
   maxLength,
   maxValue,
   memberOf,
-  minDuration,
   minLength,
   minValue,
   minimumAge,

--- a/src/validators/iso-8601-duration.js
+++ b/src/validators/iso-8601-duration.js
@@ -1,7 +1,3 @@
-import {Duration} from 'luxon';
-
-const fullName = 'duration';
-
 /**
  * ISO 8601 duration format
  *
@@ -28,6 +24,10 @@ const fullName = 'duration';
  * * PT0.1S represents a duration of 100 milliseconds.
  * * P3Y6M4DT12H30M5S represents a duration of 3 years, 6 months, 4 days, 12 hours, 30 minutes, and 5 seconds.
  */
+import {Duration} from 'luxon';
+
+const fullName = 'iso8601Duration';
+
 const validate = val => {
   if (!val) {
     return true;

--- a/src/validators/iso-8601-max-duration.js
+++ b/src/validators/iso-8601-max-duration.js
@@ -1,6 +1,6 @@
 import { Duration } from 'luxon';
 
-const fullName = 'minDuration:$1';
+const fullName = 'iso8601MaxDuration:$1';
 
 const validate = (val, ruleObj) => {
   if (!val) {
@@ -14,9 +14,9 @@ const validate = (val, ruleObj) => {
     return false;
   }
 
-  return duration.toMillis() >= max.toMillis();
+  return duration.toMillis() <= max.toMillis();
 };
 
-const message = '<%= propertyName %> must be at least <%= ruleParams[0] %>.';
+const message = '<%= propertyName %> must be at most <%= ruleParams[0] %>.';
 
 export default { fullName, validate, message };

--- a/src/validators/iso-8601-min-duration.js
+++ b/src/validators/iso-8601-min-duration.js
@@ -1,6 +1,6 @@
 import { Duration } from 'luxon';
 
-const fullName = 'maxDuration:$1';
+const fullName = 'iso8601MinDuration:$1';
 
 const validate = (val, ruleObj) => {
   if (!val) {
@@ -14,9 +14,9 @@ const validate = (val, ruleObj) => {
     return false;
   }
 
-  return duration.toMillis() <= max.toMillis();
+  return duration.toMillis() >= max.toMillis();
 };
 
-const message = '<%= propertyName %> must be at most <%= ruleParams[0] %>.';
+const message = '<%= propertyName %> must be at least <%= ruleParams[0] %>.';
 
 export default { fullName, validate, message };

--- a/test/validators/iso-8601-duration.spec.js
+++ b/test/validators/iso-8601-duration.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import validator from '../../lib';
 
-describe('Duration validator', () => {
+describe('iso8601Duration validator', () => {
   const rules = {
-    schedule: ['duration']
+    schedule: ['iso8601Duration']
   };
 
   it('should success with valid ISO 8601 duration', () => {
@@ -37,7 +37,7 @@ describe('Duration validator', () => {
 
     expect(result.success).to.equal(false);
     expect(err).to.have.property('schedule');
-    expect(err.schedule.duration).to.include('Schedule must be a valid ISO 8601 duration.');
+    expect(err.schedule['iso8601Duration']).to.include('Schedule must be a valid ISO 8601 duration.');
   });
 
   it('should fail with a plain number string', () => {
@@ -46,7 +46,7 @@ describe('Duration validator', () => {
 
     expect(result.success).to.equal(false);
     expect(err).to.have.property('schedule');
-    expect(err.schedule.duration).to.include('Schedule must be a valid ISO 8601 duration.');
+    expect(err.schedule['iso8601Duration']).to.include('Schedule must be a valid ISO 8601 duration.');
   });
 
   it('should success with duration in weeks format', () => {

--- a/test/validators/iso-8601-max-duration.spec.js
+++ b/test/validators/iso-8601-max-duration.spec.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import validator from '../../lib';
 
-describe('MinDuration validator', () => {
+describe('iso8601MaxDuration validator', () => {
   const rules = {
-    schedule: ['minDuration:PT1H']
+    schedule: ['iso8601MaxDuration:PT1H']
   };
 
-  it('should success with duration equal to minimum', () => {
+  it('should success with duration equal to maximum', () => {
     const result = validator.validate(rules, { schedule: 'PT1H' });
     const err = result.messages;
 
@@ -14,21 +14,21 @@ describe('MinDuration validator', () => {
     expect(err).to.not.have.property('schedule');
   });
 
-  it('should success with duration greater than minimum', () => {
-    const result = validator.validate(rules, { schedule: 'PT2H' });
+  it('should success with duration less than maximum', () => {
+    const result = validator.validate(rules, { schedule: 'PT30M' });
     const err = result.messages;
 
     expect(result.success).to.equal(true);
     expect(err).to.not.have.property('schedule');
   });
 
-  it('should fail with duration less than minimum', () => {
-    const result = validator.validate(rules, { schedule: 'PT30M' });
+  it('should fail with duration greater than maximum', () => {
+    const result = validator.validate(rules, { schedule: 'PT3H' });
     const err = result.messages;
 
     expect(result.success).to.equal(false);
     expect(err).to.have.property('schedule');
-    expect(err.schedule['minDuration:$1']).to.include('Schedule must be at least PT1H.');
+    expect(err.schedule['iso8601MaxDuration:$1']).to.include('Schedule must be at most PT1H.');
   });
 
   it('should success with empty value (optional field)', () => {
@@ -55,9 +55,9 @@ describe('MinDuration validator', () => {
     expect(err).to.have.property('schedule');
   });
 
-  it('should fail with invalid minimum param', () => {
+  it('should fail with invalid maximum param', () => {
     const invalidParamRules = {
-      schedule: ['minDuration:invalid-param']
+      schedule: ['iso8601MaxDuration:invalid-param']
     };
     const result = validator.validate(invalidParamRules, { schedule: 'PT1H' });
     const err = result.messages;
@@ -66,11 +66,11 @@ describe('MinDuration validator', () => {
     expect(err).to.have.property('schedule');
   });
 
-  it('should success with larger unit exceeding minimum', () => {
+  it('should fail with larger unit exceeding maximum', () => {
     const result = validator.validate(rules, { schedule: 'P1D' });
     const err = result.messages;
 
-    expect(result.success).to.equal(true);
-    expect(err).to.not.have.property('schedule');
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('schedule');
   });
 });

--- a/test/validators/iso-8601-min-duration.spec.js
+++ b/test/validators/iso-8601-min-duration.spec.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import validator from '../../lib';
 
-describe('MaxDuration validator', () => {
+describe('iso8601MinDuration validator', () => {
   const rules = {
-    schedule: ['maxDuration:PT1H']
+    schedule: ['iso8601MinDuration:PT1H']
   };
 
-  it('should success with duration equal to maximum', () => {
+  it('should success with duration equal to minimum', () => {
     const result = validator.validate(rules, { schedule: 'PT1H' });
     const err = result.messages;
 
@@ -14,21 +14,21 @@ describe('MaxDuration validator', () => {
     expect(err).to.not.have.property('schedule');
   });
 
-  it('should success with duration less than maximum', () => {
-    const result = validator.validate(rules, { schedule: 'PT30M' });
+  it('should success with duration greater than minimum', () => {
+    const result = validator.validate(rules, { schedule: 'PT2H' });
     const err = result.messages;
 
     expect(result.success).to.equal(true);
     expect(err).to.not.have.property('schedule');
   });
 
-  it('should fail with duration greater than maximum', () => {
-    const result = validator.validate(rules, { schedule: 'PT3H' });
+  it('should fail with duration less than minimum', () => {
+    const result = validator.validate(rules, { schedule: 'PT30M' });
     const err = result.messages;
 
     expect(result.success).to.equal(false);
     expect(err).to.have.property('schedule');
-    expect(err.schedule['maxDuration:$1']).to.include('Schedule must be at most PT1H.');
+    expect(err.schedule['iso8601MinDuration:$1']).to.include('Schedule must be at least PT1H.');
   });
 
   it('should success with empty value (optional field)', () => {
@@ -55,9 +55,9 @@ describe('MaxDuration validator', () => {
     expect(err).to.have.property('schedule');
   });
 
-  it('should fail with invalid maximum param', () => {
+  it('should fail with invalid minimum param', () => {
     const invalidParamRules = {
-      schedule: ['maxDuration:invalid-param']
+      schedule: ['iso8601MinDuration:invalid-param']
     };
     const result = validator.validate(invalidParamRules, { schedule: 'PT1H' });
     const err = result.messages;
@@ -66,11 +66,11 @@ describe('MaxDuration validator', () => {
     expect(err).to.have.property('schedule');
   });
 
-  it('should fail with larger unit exceeding maximum', () => {
+  it('should success with larger unit exceeding minimum', () => {
     const result = validator.validate(rules, { schedule: 'P1D' });
     const err = result.messages;
 
-    expect(result.success).to.equal(false);
-    expect(err).to.have.property('schedule');
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('schedule');
   });
 });


### PR DESCRIPTION
renamed all `duration` validators to include prefix `iso8601-`.
- `duration` -> `iso8601Duration`
- `minDuration` -> `iso8601MinDuration`
- `maxDuration` -> `iso8601MaxDuration`