### PR TITLE
[T151710] - [Assembler api migration] : add validator for min and max array size

### DIFF
--- a/src/validators/max-items.js
+++ b/src/validators/max-items.js
@@ -1,0 +1,13 @@
+import isNil from 'ramda/src/isNil';
+
+const fullName = 'maxItems:$1';
+
+const validate = (val, ruleObj) => {
+  if (isNil(val)) return true;
+  if (!Array.isArray(val)) return false;
+  return val.length <= Number(ruleObj.params[0]);
+};
+
+const message = '<%= propertyName %> must have at most <%= ruleParams[0] %> item(s).';
+
+export default { fullName, validate, message };

--- a/src/validators/min-items.js
+++ b/src/validators/min-items.js
@@ -1,0 +1,13 @@
+import isNil from 'ramda/src/isNil';
+
+const fullName = 'minItems:$1';
+
+const validate = (val, ruleObj) => {
+  if (isNil(val)) return true;
+  if (!Array.isArray(val)) return false;
+  return val.length >= Number(ruleObj.params[0]);
+};
+
+const message = '<%= propertyName %> must have at least <%= ruleParams[0] %> item(s).';
+
+export default { fullName, validate, message };

--- a/test/validators/max-items.spec.js
+++ b/test/validators/max-items.spec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MaxItems validator', () => {
+  const rules = {
+    phoneNumbers: ['maxItems:3']
+  };
+
+  it('should success when array length is equal to max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array length is less than max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array is empty', () => {
+    const result = validator.validate(rules, { phoneNumbers: [] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when value is nil', () => {
+    const result = validator.validate(rules, { phoneNumbers: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should fail when array length is greater than max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111', '+6282222222222'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['maxItems:$1']).to.equal('Phone Numbers must have at most 3 item(s).');
+  });
+
+  it('should fail when value is not an array', () => {
+    const result = validator.validate(rules, { phoneNumbers: '+6281234567890' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['maxItems:$1']).to.equal('Phone Numbers must have at most 3 item(s).');
+  });
+});

--- a/test/validators/min-items.spec.js
+++ b/test/validators/min-items.spec.js
@@ -1,0 +1,60 @@
+// test/validators/min-items.spec.js
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MinItems validator', () => {
+  const rules = {
+    phoneNumbers: ['minItems:2']
+  };
+
+  it('should success when array length is equal to min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array length is greater than min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when value is nil', () => {
+    const result = validator.validate(rules, { phoneNumbers: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should fail when array length is less than min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minItems:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+
+  it('should fail when array is empty', () => {
+    const result = validator.validate(rules, { phoneNumbers: [] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minItems:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+
+  it('should fail when value is not an array', () => {
+    const result = validator.validate(rules, { phoneNumbers: '+6281234567890' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minItems:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+});


### PR DESCRIPTION
Context : we need to create API for assembler migration. But some query pattern has bulk request in arrays., eg: idNumbers. So we would like to add validator for array size to limit the request size.