### PR TITLE
[T151710] - [Assembler api migration] : add validator for min and max array size

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ const result = customValidator.validate(
 - `fileType:<extension>` Please check [file-type](https://github.com/sindresorhus/file-type)
 - `maxLength:<length>`
 - `minLength:<length>`
+- `maxArraySize:<count>` Check if the given array has at most `<count>` items
+- `minArraySize:<count>` Check if the given array has at least `<count>` items
+  ```js
+  const rules = {
+    documents: ['maxArraySize:2', 'minArraySize:1']
+  };
+
+  satpam.validate(rules, {
+    documents: ['identity-card.jpg']
+  }); // {success: true}
+
+  satpam.validate(rules, {
+    documents: [
+      'identity-card.jpg',
+      'selfie.jpg',
+      'tax-card.jpg'
+    ]
+  }); // {success: false}
+  ```
+
 - `maxValue:<max value>`
 - `minValue:<min value>`
 - `memberOf:$1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "satpam",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "satpam",
-      "version": "4.21.0",
+      "version": "4.22.0",
       "license": "MIT",
       "dependencies": {
         "file-type": "~3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satpam",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "description": "Simple and Effective Object Validator",
   "main": "lib/index.js",
   "scripts": {

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -64,6 +64,9 @@ import iso8601Duration from '../validators/iso-8601-duration';
 import iso8601MinDuration from '../validators/iso-8601-min-duration';
 import iso8601MaxDuration from '../validators/iso-8601-max-duration';
 
+import maxArraySize from '../validators/max-array-size';
+import minArraySize from '../validators/min-array-size';
+
 let validators = [
   alpha,
   alphanumeric,
@@ -99,6 +102,8 @@ let validators = [
   iso8601MinDuration,
   iso8601MaxDuration,
   length,
+  maxArraySize,
+  minArraySize
   maxLength,
   maxValue,
   memberOf,

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,8 @@ import mustHaveAllPrefixes from './validators/must-have-all-prefixes';
 import iso8601Duration from './validators/iso-8601-duration';
 import iso8601MinDuration from './validators/iso-8601-min-duration';
 import iso8601MaxDuration from './validators/iso-8601-max-duration';
+import maxArraySize from './validators/max-array-size';
+import minArraySize from './validators/min-array-size';
 
 let validators = [
   alpha,
@@ -138,6 +140,8 @@ let validators = [
   iso8601MinDuration,
   iso8601MaxDuration,
   length,
+  maxArraySize,
+  minArraySize
   maxLength,
   maxValue,
   memberOf,

--- a/src/validators/max-array-size.js
+++ b/src/validators/max-array-size.js
@@ -1,0 +1,19 @@
+import is from 'ramda/src/is';
+import isNil from 'ramda/src/isNil';
+
+const fullName = 'maxArraySize:$1';
+
+const validate = (val, ruleObj) => {
+  if (isNil(val)) {
+    return true;
+  }
+  if (!is(Array, val)) {
+    return false;
+  }
+  
+  return val.length <= Number(ruleObj.params[0]);
+};
+
+const message = '<%= propertyName %> must have at most <%= ruleParams[0] %> item(s).';
+
+export default { fullName, validate, message };

--- a/src/validators/min-array-size.js
+++ b/src/validators/min-array-size.js
@@ -1,0 +1,19 @@
+import is from 'ramda/src/is';
+import isNil from 'ramda/src/isNil';
+
+const fullName = 'minArraySize:$1';
+
+const validate = (val, ruleObj) => {
+  if (isNil(val)) {
+    return true;
+  }
+  if (!is(Array, val)) {
+    return false;
+  }
+  
+  return val.length >= Number(ruleObj.params[0]);
+};
+
+const message = '<%= propertyName %> must have at least <%= ruleParams[0] %> item(s).';
+
+export default { fullName, validate, message };

--- a/test/validators/max-array-size.spec.js
+++ b/test/validators/max-array-size.spec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MaxArraySize validator', () => {
+  const rules = {
+    phoneNumbers: ['maxArraySize:3']
+  };
+
+  it('should success when array length is equal to max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array length is less than max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array is empty', () => {
+    const result = validator.validate(rules, { phoneNumbers: [] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when value is nil', () => {
+    const result = validator.validate(rules, { phoneNumbers: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should fail when array length is greater than max', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111', '+6282222222222'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['maxArraySize:$1']).to.equal('Phone Numbers must have at most 3 item(s).');
+  });
+
+  it('should fail when value is not an array', () => {
+    const result = validator.validate(rules, { phoneNumbers: '+6281234567890' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['maxArraySize:$1']).to.equal('Phone Numbers must have at most 3 item(s).');
+  });
+});

--- a/test/validators/min-array-size.spec.js
+++ b/test/validators/min-array-size.spec.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import validator from '../../lib';
+
+describe('MinArraySize validator', () => {
+  const rules = {
+    phoneNumbers: ['minArraySize:2']
+  };
+
+  it('should success when array length is equal to min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when array length is greater than min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890', '+6289876543210', '+6281111111111'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should success when value is nil', () => {
+    const result = validator.validate(rules, { phoneNumbers: null });
+    const err = result.messages;
+
+    expect(result.success).to.equal(true);
+    expect(err).to.not.have.property('phoneNumbers');
+  });
+
+  it('should fail when array length is less than min', () => {
+    const result = validator.validate(rules, { phoneNumbers: ['+6281234567890'] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minArraySize:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+
+  it('should fail when array is empty', () => {
+    const result = validator.validate(rules, { phoneNumbers: [] });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minArraySize:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+
+  it('should fail when value is not an array', () => {
+    const result = validator.validate(rules, { phoneNumbers: '+6281234567890' });
+    const err = result.messages;
+
+    expect(result.success).to.equal(false);
+    expect(err).to.have.property('phoneNumbers');
+    expect(err.phoneNumbers['minArraySize:$1']).to.equal('Phone Numbers must have at least 2 item(s).');
+  });
+});


### PR DESCRIPTION
Context : we need to create API for assembler migration. But some query pattern has bulk request in arrays., eg: idNumbers. So we would like to add validator for array size to limit the request size.